### PR TITLE
Implement quest board UI and quest seeding

### DIFF
--- a/backend/prisma/migrations/20251209130833_add_quest_metadata/migration.sql
+++ b/backend/prisma/migrations/20251209130833_add_quest_metadata/migration.sql
@@ -1,0 +1,21 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Quest" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "baseXp" INTEGER NOT NULL DEFAULT 10,
+    "briefText" TEXT,
+    "difficulty" TEXT NOT NULL DEFAULT 'easy',
+    "leanConcept" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "areaId" INTEGER,
+    CONSTRAINT "Quest_areaId_fkey" FOREIGN KEY ("areaId") REFERENCES "Area" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Quest" ("areaId", "baseXp", "description", "id", "isActive", "title", "type") SELECT "areaId", "baseXp", "description", "id", "isActive", "title", "type" FROM "Quest";
+DROP TABLE "Quest";
+ALTER TABLE "new_Quest" RENAME TO "Quest";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,9 @@ model Quest {
   description String
   type        String
   baseXp      Int           @default(10)
+  briefText   String?
+  difficulty  String        @default("easy")
+  leanConcept String?
   isActive    Boolean       @default(true)
   areaId      Int?
   area        Area?         @relation(fields: [areaId], references: [id])

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -98,10 +98,64 @@ async function seedAuditTemplates(areasByName: Record<string, number>) {
   }
 }
 
+async function seedQuests() {
+  const quests = [
+    {
+      title: "Welcome to Lean RPG",
+      description: "Nauč se základy Lean methodologie a 5S.",
+      briefText: "Tvá první mise. Poznáš světem Lean a začneš budovat své dovednosti.",
+      baseXp: 50,
+      difficulty: "easy",
+      leanConcept: "5S",
+      type: "story",
+    },
+    {
+      title: "First 5S Audit",
+      description: "Proveď svou první audit podle 5S - Sort, Set in order, Shine, Standardize, Sustain.",
+      briefText: "Zkontroluj pracoviště a aplikuj principy 5S.",
+      baseXp: 100,
+      difficulty: "medium",
+      leanConcept: "5S",
+      type: "mission",
+    },
+    {
+      title: "Identify Waste (Muda)",
+      description: "Najdi druhy muda ve virtuálním procesu a navrhni zlepšení.",
+      briefText: "Procvič si identifikaci plýtvání v procesu.",
+      baseXp: 75,
+      difficulty: "medium",
+      leanConcept: "Muda",
+      type: "challenge",
+    },
+    {
+      title: "Problem Solving with 5 Why",
+      description: "Řeš problém pomocí techniky 5 Why.",
+      briefText: "Když se na lince objeví chyba, zjisti skutečnou příčinu.",
+      baseXp: 80,
+      difficulty: "medium",
+      leanConcept: "Problem Solving",
+      type: "challenge",
+    },
+    {
+      title: "Master Kaizen Ideas",
+      description: "Sbír a implementuj návrhy na zlepšení od týmu.",
+      briefText: "Vede tým k nepřetržitému zlepšování skrz Kaizen.",
+      baseXp: 120,
+      difficulty: "hard",
+      leanConcept: "Kaizen",
+      type: "mission",
+    },
+  ];
+
+  await prisma.quest.deleteMany({ where: { title: { in: quests.map((quest) => quest.title) } } });
+  await prisma.quest.createMany({ data: quests });
+}
+
 async function main() {
   await seedSkills();
   const areasByName = await seedAreas();
   await seedAuditTemplates(areasByName);
+  await seedQuests();
 }
 
 main()

--- a/frontend/app/(game)/quests/page.tsx
+++ b/frontend/app/(game)/quests/page.tsx
@@ -1,13 +1,82 @@
-import { Card } from '@/components/ui/card';
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Quest, fetchQuests } from '@/lib/quests';
+import { QuestCard } from '@/components/game/quest-card';
+import { Loader2 } from 'lucide-react';
 
 export default function QuestsPage() {
+  const [quests, setQuests] = useState<Quest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadQuests = async () => {
+      try {
+        setLoading(true);
+        const data = await fetchQuests();
+        setQuests(data);
+      } catch (err) {
+        console.error('Failed to load quests:', err);
+        setError('Nepodařilo se načíst questy. Zkuste to později.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadQuests();
+  }, []);
+
+  const handleStartQuest = (questId: number) => {
+    console.log(`Starting quest ${questId}`);
+    // TODO: Later - navigace na quest detail nebo start dialog
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex items-center gap-2 text-gray-700">
+          <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+          <span>Načítám úkoly...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-red-800">
+        <p className="font-medium">{error}</p>
+      </div>
+    );
+  }
+
+  if (quests.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center text-gray-700">
+        <p>Zatím nejsou k dispozici žádné úkoly.</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-4">
-      <Card title="Úkoly" description="Sekce pro úkoly bude brzy dostupná.">
-        <p className="text-sm text-gray-700">
-          Připravujeme seznam questů, na kterých budete moct pracovat. Sledujte nás!
-        </p>
-      </Card>
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Úkoly (Questy)</h1>
+        <p className="text-gray-600 mt-1">Vyber si úkol a začni si získávat XP a dovednosti.</p>
+      </div>
+
+      {/* Grid */}
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {quests.map((quest) => (
+          <QuestCard
+            key={quest.id}
+            quest={quest}
+            onStart={handleStartQuest}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/components/game/quest-card.tsx
+++ b/frontend/components/game/quest-card.tsx
@@ -1,0 +1,47 @@
+// Quest card component
+
+import { Quest, getDifficultyColor } from '@/lib/quests';
+
+interface QuestCardProps {
+  quest: Quest;
+  onStart: (questId: number) => void;
+}
+
+export function QuestCard({ quest, onStart }: QuestCardProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm hover:shadow-md transition">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-3">
+        <h3 className="text-lg font-semibold text-gray-900">{quest.title}</h3>
+        <span className={`px-2 py-1 text-xs font-semibold rounded-full ${getDifficultyColor(quest.difficulty)}`}>
+          {quest.difficulty}
+        </span>
+      </div>
+
+      {/* Description */}
+      <p className="text-sm text-gray-600 mb-4">{quest.description}</p>
+
+      {/* Lean Concept Badge */}
+      {quest.leanConcept && (
+        <div className="mb-4">
+          <span className="inline-block px-3 py-1 text-xs bg-blue-100 text-blue-800 rounded-full">
+            {quest.leanConcept}
+          </span>
+        </div>
+      )}
+
+      {/* Footer: XP + Button */}
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium text-gray-700">
+          <span className="text-yellow-600">+{quest.baseXp} XP</span>
+        </div>
+        <button
+          onClick={() => onStart(quest.id)}
+          className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 transition"
+        >
+          Start Quest
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/quests.ts
+++ b/frontend/lib/quests.ts
@@ -1,0 +1,34 @@
+import api from './api';
+
+export type Quest = {
+  id: number;
+  title: string;
+  description: string;
+  baseXp: number;
+  difficulty: 'easy' | 'medium' | 'hard';
+  leanConcept?: string;
+};
+
+/**
+ * Načti všechny dostupné questy z backendu
+ */
+export async function fetchQuests(): Promise<Quest[]> {
+  const response = await api.get('/api/quests');
+  return response.data;
+}
+
+/**
+ * Vrátí barvu pro difficulty badge
+ */
+export function getDifficultyColor(difficulty: string): string {
+  switch (difficulty) {
+    case 'easy':
+      return 'bg-green-100 text-green-800';
+    case 'medium':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'hard':
+      return 'bg-red-100 text-red-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+}


### PR DESCRIPTION
## Summary
- add quest metadata fields to the schema and seed five sample quests
- include quest fetching helpers and card component for quest display
- replace quests page placeholder with live data grid plus loading/error/empty states

## Testing
- npm run build (frontend) *(fails: Next.js not installed; npm registry access blocked to install dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381efcb4f48330acc18b696bd61c61)