### PR TITLE
Add engagement features to Gemba experience

### DIFF
--- a/backend/src/routes/gemba.ts
+++ b/backend/src/routes/gemba.ts
@@ -5,6 +5,9 @@ import {
   ensureUser,
   getAreaDetail,
   getAreasForUser,
+  getBadgeProgress,
+  getDailyChallenge,
+  getLeaderboardSummary,
   getNpcDialogWithProblem,
   getProblemById,
   getQuestById,
@@ -12,6 +15,8 @@ import {
   startQuest,
   submitQuestAnswer,
   summarizeQuestProgress,
+  listIdeasForUser,
+  submitIdea,
 } from "../services/gembaService.js";
 import { ValidationError } from "../middleware/errors.js";
 
@@ -25,6 +30,13 @@ const questSubmissionSchema = z.object({
   why5: z.string().min(2),
   rootCause: z.string().min(2),
   solutionId: z.number(),
+});
+
+const ideaSubmissionSchema = z.object({
+  title: z.string().min(3),
+  problemContext: z.string().min(10),
+  proposedSolution: z.string().min(10),
+  impact: z.string().min(5),
 });
 
 router.get(
@@ -115,6 +127,55 @@ router.get(
     const user = await ensureUser(req.user);
     const progress = summarizeQuestProgress(user.id);
     res.json({ progress });
+  })
+);
+
+router.get(
+  "/leaderboard",
+  asyncHandler(async (_req: Request, res: Response) => {
+    const leaderboard = getLeaderboardSummary();
+    res.json(leaderboard);
+  })
+);
+
+router.get(
+  "/daily-challenge",
+  asyncHandler(async (_req: Request, res: Response) => {
+    const challenge = getDailyChallenge();
+    res.json(challenge);
+  })
+);
+
+router.get(
+  "/badges",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const badges = getBadgeProgress(user.id);
+    res.json(badges);
+  })
+);
+
+router.get(
+  "/ideas",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const ideas = listIdeasForUser(user.id);
+    res.json({ ideas });
+  })
+);
+
+router.post(
+  "/ideas",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const parsed = ideaSubmissionSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      throw new ValidationError("Invalid idea submission", parsed.error.flatten());
+    }
+
+    const idea = submitIdea(user.id, parsed.data);
+    res.status(201).json({ idea });
   })
 );
 

--- a/backend/src/services/gembaService.ts
+++ b/backend/src/services/gembaService.ts
@@ -93,6 +93,56 @@ export type UserProgress = {
   totalXp: number;
 };
 
+export type LeaderboardEntry = {
+  userId: number;
+  name: string;
+  role: "employee" | "specialist";
+  level: number;
+  xp: number;
+  team: string;
+  badges: number;
+  ideasApproved: number;
+};
+
+export type LeaderboardSummary = {
+  global: LeaderboardEntry[];
+  teams: { team: string; score: number; members: number }[];
+};
+
+export type DailyChallenge = {
+  id: number;
+  title: string;
+  description: string;
+  rewardXp: number;
+  rewardPoints: number;
+  conceptFocus: LeanConcept;
+};
+
+export type BadgeSummary = {
+  id: number;
+  name: string;
+  description: string;
+  icon: string;
+  requirement: string;
+  xpReward: number;
+  pointsReward: number;
+  earnedAt?: Date;
+};
+
+export type IdeaPayload = {
+  title: string;
+  problemContext: string;
+  proposedSolution: string;
+  impact: string;
+};
+
+export type IdeaSubmission = IdeaPayload & {
+  id: number;
+  userId: number;
+  status: "submitted" | "under_review" | "approved" | "rejected";
+  submittedAt: Date;
+};
+
 const gembaAreas: GembaArea[] = [
   {
     id: 1,
@@ -977,6 +1027,147 @@ const gembaProblems: GembaProblem[] = [
   },
 ];
 
+const leaderboardEntries: LeaderboardEntry[] = [
+  {
+    userId: 1,
+    name: "Sarah Johnson",
+    role: "employee",
+    level: 6,
+    xp: 1840,
+    team: "Assembly",
+    badges: 5,
+    ideasApproved: 2,
+  },
+  {
+    userId: 2,
+    name: "Juan Rodriguez",
+    role: "employee",
+    level: 5,
+    xp: 1620,
+    team: "Injection",
+    badges: 4,
+    ideasApproved: 1,
+  },
+  {
+    userId: 3,
+    name: "Emily Chen",
+    role: "employee",
+    level: 5,
+    xp: 1535,
+    team: "Assembly",
+    badges: 4,
+    ideasApproved: 3,
+  },
+  {
+    userId: 4,
+    name: "Marcus Chen",
+    role: "specialist",
+    level: 7,
+    xp: 2100,
+    team: "CI Specialists",
+    badges: 6,
+    ideasApproved: 8,
+  },
+  {
+    userId: 5,
+    name: "Viktor Müller",
+    role: "specialist",
+    level: 8,
+    xp: 2450,
+    team: "CI Specialists",
+    badges: 7,
+    ideasApproved: 10,
+  },
+  {
+    userId: 6,
+    name: "Grace Kim",
+    role: "employee",
+    level: 4,
+    xp: 980,
+    team: "Painting",
+    badges: 3,
+    ideasApproved: 1,
+  },
+];
+
+const teamStandings = [
+  { team: "Assembly", score: 4820, members: 3 },
+  { team: "Injection", score: 3610, members: 2 },
+  { team: "Painting", score: 2440, members: 2 },
+  { team: "Warehouse", score: 1870, members: 2 },
+  { team: "CI Specialists", score: 4550, members: 2 },
+];
+
+const dailyChallenges: DailyChallenge[] = [
+  {
+    id: 1,
+    title: "Solve 3 Muda problems",
+    description: "Hunt for waiting time, rework, or overproduction issues today.",
+    rewardXp: 50,
+    rewardPoints: 20,
+    conceptFocus: "Muda",
+  },
+  {
+    id: 2,
+    title: "Submit a Kaizen idea",
+    description: "Share one improvement you noticed during your shift.",
+    rewardXp: 100,
+    rewardPoints: 50,
+    conceptFocus: "Kaizen",
+  },
+];
+
+const availableBadges: BadgeSummary[] = [
+  {
+    id: 1,
+    name: "Muda Hunter",
+    description: "Solve 5 Muda problems",
+    icon: "🔴",
+    requirement: "5 Muda quests completed",
+    xpReward: 100,
+    pointsReward: 20,
+  },
+  {
+    id: 2,
+    name: "5S Specialist",
+    description: "Complete all 5S challenges",
+    icon: "⭐",
+    requirement: "Finish 3 workplace organization quests",
+    xpReward: 200,
+    pointsReward: 40,
+  },
+  {
+    id: 3,
+    name: "Kaizen Champion",
+    description: "Submit 3 implemented ideas",
+    icon: "🏆",
+    requirement: "Ideas approved by CI team",
+    xpReward: 300,
+    pointsReward: 75,
+  },
+  {
+    id: 4,
+    name: "Gemba Explorer",
+    description: "Visit three areas in one week",
+    icon: "🗺️",
+    requirement: "Explore Injection, Assembly, and Painting",
+    xpReward: 80,
+    pointsReward: 15,
+  },
+];
+
+const earnedBadges = new Map<number, BadgeSummary[]>([
+  [
+    1,
+    [
+      { ...availableBadges[0], earnedAt: new Date() },
+      { ...availableBadges[3], earnedAt: new Date() },
+    ],
+  ],
+]);
+
+const ideaSubmissions = new Map<number, IdeaSubmission[]>();
+
 const questStates = new Map<string, QuestState>();
 
 function questKey(userId: number, questId: number) {
@@ -1145,4 +1336,42 @@ export function getNpcDialogWithProblem(npcId: number) {
     ...npc,
     problems,
   };
+}
+
+export function getLeaderboardSummary(): LeaderboardSummary {
+  const global = [...leaderboardEntries].sort((a, b) => b.xp - a.xp).slice(0, 10);
+  const teams = [...teamStandings].sort((a, b) => b.score - a.score);
+  return { global, teams };
+}
+
+export function getDailyChallenge(): DailyChallenge {
+  return dailyChallenges[0];
+}
+
+export function getBadgeProgress(userId: number) {
+  const earned = earnedBadges.get(userId) ?? [];
+  return {
+    available: availableBadges,
+    earned,
+  };
+}
+
+let ideaIdCounter = 1;
+
+export function listIdeasForUser(userId: number) {
+  return ideaSubmissions.get(userId) ?? [];
+}
+
+export function submitIdea(userId: number, payload: IdeaPayload): IdeaSubmission {
+  const existing = ideaSubmissions.get(userId) ?? [];
+  const submission: IdeaSubmission = {
+    ...payload,
+    id: ideaIdCounter++,
+    userId,
+    status: "submitted",
+    submittedAt: new Date(),
+  };
+
+  ideaSubmissions.set(userId, [submission, ...existing]);
+  return submission;
 }

--- a/frontend/lib/api/gemba.ts
+++ b/frontend/lib/api/gemba.ts
@@ -75,6 +75,52 @@ export type QuestState = {
   analysisQuality?: number;
 };
 
+export type LeaderboardEntry = {
+  userId: number;
+  name: string;
+  role: 'employee' | 'specialist';
+  level: number;
+  xp: number;
+  team: string;
+  badges: number;
+  ideasApproved: number;
+};
+
+export type LeaderboardSummary = {
+  global: LeaderboardEntry[];
+  teams: { team: string; score: number; members: number }[];
+};
+
+export type DailyChallenge = {
+  id: number;
+  title: string;
+  description: string;
+  rewardXp: number;
+  rewardPoints: number;
+  conceptFocus: string;
+};
+
+export type BadgeSummary = {
+  id: number;
+  name: string;
+  description: string;
+  icon: string;
+  requirement: string;
+  xpReward: number;
+  pointsReward: number;
+  earnedAt?: string;
+};
+
+export type IdeaSubmission = {
+  id: number;
+  title: string;
+  problemContext: string;
+  proposedSolution: string;
+  impact: string;
+  status: string;
+  submittedAt: string;
+};
+
 export async function fetchAreas(): Promise<GembaAreaSummary[]> {
   const response = await fetch(`${API_BASE}/gemba/areas`, {
     headers: {
@@ -169,4 +215,92 @@ export async function submitQuest(
   }
 
   return response.json();
+}
+
+export async function fetchLeaderboard(): Promise<LeaderboardSummary> {
+  const response = await fetch(`${API_BASE}/gemba/leaderboard`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load leaderboard');
+  }
+
+  return response.json();
+}
+
+export async function fetchDailyChallenge(): Promise<DailyChallenge> {
+  const response = await fetch(`${API_BASE}/gemba/daily-challenge`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load daily challenge');
+  }
+
+  return response.json();
+}
+
+export async function fetchBadges(): Promise<{ available: BadgeSummary[]; earned: BadgeSummary[] }> {
+  const response = await fetch(`${API_BASE}/gemba/badges`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load badges');
+  }
+
+  return response.json();
+}
+
+export async function fetchIdeas(): Promise<IdeaSubmission[]> {
+  const response = await fetch(`${API_BASE}/gemba/ideas`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load ideas');
+  }
+
+  const data = await response.json();
+  return data.ideas;
+}
+
+export async function submitIdea(payload: {
+  title: string;
+  problemContext: string;
+  proposedSolution: string;
+  impact: string;
+}): Promise<IdeaSubmission> {
+  const response = await fetch(`${API_BASE}/gemba/ideas`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to submit idea');
+  }
+
+  const data = await response.json();
+  return data.idea;
 }

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -9,6 +9,7 @@ export type User = {
   email: string;
   level?: number;
   xp?: number;
+  totalXp?: number;
 };
 
 type AuthContextValue = {


### PR DESCRIPTION
## Summary
- add leaderboard, badges, daily challenge, and idea submission endpoints to the Gemba API
- expand the Gemba player view with profile stats, challenges, leaderboards, badges, and an idea submission workflow
- extend frontend API types and auth user data to surface XP totals alongside new engagement widgets

## Testing
- npm run build --prefix backend
- npm run build --prefix frontend (fails: Next.js TS config error about missing next/tsconfig.json)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393c83efa0833084aa23d8be0c075f)