### PR TITLE
Add 5S audit mini-game backend and UI

### DIFF
--- a/backend/prisma/migrations/0002_add_five_s_models/migration.sql
+++ b/backend/prisma/migrations/0002_add_five_s_models/migration.sql
@@ -1,0 +1,72 @@
+-- CreateTable
+CREATE TABLE "FiveSSetting" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "areaId" INTEGER NOT NULL,
+    "sortCriteria" JSONB NOT NULL,
+    "orderCriteria" JSONB NOT NULL,
+    "shineCriteria" JSONB NOT NULL,
+    "standardizeCriteria" JSONB NOT NULL,
+    "sustainCriteria" JSONB NOT NULL,
+    "maxScore" INTEGER NOT NULL DEFAULT 100,
+    "passingScore" INTEGER NOT NULL DEFAULT 70,
+    "timeLimit" INTEGER NOT NULL,
+    "maxProblems" INTEGER NOT NULL DEFAULT 5,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "FiveSSetting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FiveSAudit" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "settingId" INTEGER NOT NULL,
+    "areaId" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'in_progress',
+    "sortScore" INTEGER,
+    "orderScore" INTEGER,
+    "shineScore" INTEGER,
+    "standardizeScore" INTEGER,
+    "sustainScore" INTEGER,
+    "totalScore" INTEGER,
+    "problemsFound" JSONB,
+    "aiFeedback" TEXT,
+    "mainIssue" TEXT,
+    "xpGain" INTEGER NOT NULL DEFAULT 0,
+    "pointsGain" INTEGER NOT NULL DEFAULT 0,
+    "badgeEarned" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "timeSpent" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FiveSAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FiveSProblem" (
+    "id" SERIAL NOT NULL,
+    "auditId" INTEGER NOT NULL,
+    "category" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "position" TEXT NOT NULL,
+    "screenshot" TEXT,
+    "severity" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FiveSProblem_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "FiveSSetting" ADD CONSTRAINT "FiveSSetting_areaId_fkey" FOREIGN KEY ("areaId") REFERENCES "Area"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FiveSAudit" ADD CONSTRAINT "FiveSAudit_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FiveSAudit" ADD CONSTRAINT "FiveSAudit_settingId_fkey" FOREIGN KEY ("settingId") REFERENCES "FiveSSetting"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FiveSAudit" ADD CONSTRAINT "FiveSAudit_areaId_fkey" FOREIGN KEY ("areaId") REFERENCES "Area"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FiveSProblem" ADD CONSTRAINT "FiveSProblem_auditId_fkey" FOREIGN KEY ("auditId") REFERENCES "FiveSAudit"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   userSkills UserSkill[]
   audits     Audit[]
   submissions Submission[]
+  fiveSAudits FiveSAudit[]
 }
 
 model Area {
@@ -32,6 +33,8 @@ model Area {
   quests         Quest[]
   knowledgePacks KnowledgePack[]
   auditTemplates AuditTemplate[]
+  fiveSSettings  FiveSSetting[]
+  fiveSAudits    FiveSAudit[]
 }
 
 model Workstation {
@@ -183,4 +186,78 @@ model AuditResult {
   score   Int
   audit   Audit     @relation(fields: [auditId], references: [id])
   item    AuditItem @relation(fields: [itemId], references: [id])
+}
+
+model FiveSSetting {
+  id                  Int          @id @default(autoincrement())
+  name                String
+  areaId              Int
+  area                Area         @relation(fields: [areaId], references: [id])
+
+  sortCriteria        Json
+  orderCriteria       Json
+  shineCriteria       Json
+  standardizeCriteria Json
+  sustainCriteria     Json
+
+  maxScore            Int          @default(100)
+  passingScore        Int          @default(70)
+
+  timeLimit           Int
+  maxProblems         Int          @default(5)
+
+  audits              FiveSAudit[]
+  createdAt           DateTime     @default(now())
+  updatedAt           DateTime     @updatedAt
+}
+
+model FiveSAudit {
+  id                Int            @id @default(autoincrement())
+  userId            Int
+  user              User           @relation(fields: [userId], references: [id])
+
+  settingId         Int
+  setting           FiveSSetting   @relation(fields: [settingId], references: [id])
+
+  areaId            Int
+  area              Area           @relation(fields: [areaId], references: [id])
+
+  status            String         @default("in_progress")
+
+  sortScore         Int?
+  orderScore        Int?
+  shineScore        Int?
+  standardizeScore  Int?
+  sustainScore      Int?
+  totalScore        Int?
+
+  problemsFound     Json?
+
+  aiFeedback        String?
+  mainIssue         String?
+
+  xpGain            Int            @default(0)
+  pointsGain        Int            @default(0)
+  badgeEarned       String?
+
+  startedAt         DateTime       @default(now())
+  completedAt       DateTime?
+  timeSpent         Int?
+
+  createdAt         DateTime       @default(now())
+  problems          FiveSProblem[]
+}
+
+model FiveSProblem {
+  id          Int         @id @default(autoincrement())
+  auditId     Int
+  audit       FiveSAudit  @relation(fields: [auditId], references: [id], onDelete: Cascade)
+
+  category    String
+  description String
+  position    String
+  screenshot  String?
+  severity    String
+
+  createdAt   DateTime    @default(now())
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -98,6 +98,167 @@ async function seedAuditTemplates(areasByName: Record<string, number>) {
   }
 }
 
+async function seedFiveSSettings(areasByName: Record<string, number>) {
+  const injectionId = areasByName["Injection Molding"];
+
+  if (!injectionId) return;
+
+  const checklist = {
+    name: "Injection Department 5S Checklist",
+    areaId: injectionId,
+    timeLimit: 300,
+    sortCriteria: [
+      {
+        id: 1,
+        question: "Vidíš zbytečné věci na stanicích?",
+        hint: "Staré nářadí, obaly, papír, věci z jiných oddělení",
+        points: 4,
+      },
+      {
+        id: 2,
+        question: "Nejsou nástroje z jiných stanic?",
+        hint: "Může to vytvořit zmatek a zpomalení",
+        points: 4,
+      },
+      {
+        id: 3,
+        question: "Je všechno na správném místě?",
+        hint: "Vči standardu pracovního místa",
+        points: 4,
+      },
+      {
+        id: 4,
+        question: "Vidíš praskliny nebo poškozená zařízení?",
+        hint: "Bezpečnostní riziko",
+        points: 4,
+      },
+      {
+        id: 5,
+        question: "Jsou kontrolní body jasně viditelné?",
+        hint: "Čtverečky na podlaze, značky na nářadí",
+        points: 4,
+      },
+    ],
+    orderCriteria: [
+      {
+        id: 6,
+        question: "Je vše na svém místě (location markers)?",
+        hint: "Nářadí má svou polohu",
+        points: 4,
+      },
+      {
+        id: 7,
+        question: "Jsou nářadí a materiály označeny?",
+        hint: "Barevné štítky, shadow boards",
+        points: 4,
+      },
+      {
+        id: 8,
+        question: "Jsou cesty a průchody volné?",
+        hint: "Bez překážek a nepořádku",
+        points: 4,
+      },
+      {
+        id: 9,
+        question: "Je jasné, kam patří odpady?",
+        hint: "Označené koše a boxy",
+        points: 4,
+      },
+    ],
+    shineCriteria: [
+      {
+        id: 10,
+        question: "Je podlaha čistá?",
+        hint: "Bez oleje, úniků a prachu",
+        points: 4,
+      },
+      {
+        id: 11,
+        question: "Jsou stroje bez nečistot?",
+        hint: "Čisté povrchy a senzory",
+        points: 4,
+      },
+      {
+        id: 12,
+        question: "Je pracovní plocha uklizená?",
+        hint: "Bez zbytků materiálu",
+        points: 4,
+      },
+      {
+        id: 13,
+        question: "Jsou úklidové nástroje dostupné?",
+        hint: "Koště, utěrky, čistící prostředky",
+        points: 4,
+      },
+    ],
+    standardizeCriteria: [
+      {
+        id: 14,
+        question: "Jsou vidět 5S pravidla (plakáty)?",
+        hint: "Instrukce a checklisty",
+        points: 4,
+      },
+      {
+        id: 15,
+        question: "Je odpovědnost jasně přiřazena?",
+        hint: "Tabulky směn, ownership",
+        points: 4,
+      },
+      {
+        id: 16,
+        question: "Jsou standardy aktuální?",
+        hint: "Poslední revize a podpis",
+        points: 4,
+      },
+      {
+        id: 17,
+        question: "Je kontrolní kolo pravidelné?",
+        hint: "Denní 5S checklist",
+        points: 4,
+      },
+    ],
+    sustainCriteria: [
+      {
+        id: 18,
+        question: "Drží se lidi pravidel?",
+        hint: "Pozorování disciplíny",
+        points: 4,
+      },
+      {
+        id: 19,
+        question: "Jsou akční plány uzavřené?",
+        hint: "Splněné úkoly z posledního auditu",
+        points: 4,
+      },
+      {
+        id: 20,
+        question: "Probíhá trénink nováčků?",
+        hint: "Onboarding 5S",
+        points: 4,
+      },
+      {
+        id: 21,
+        question: "Je trend skóre pozitivní?",
+        hint: "Poslední výsledky",
+        points: 4,
+      },
+    ],
+    maxScore: 100,
+    passingScore: 70,
+    maxProblems: 5,
+  };
+
+  const existing = await prisma.fiveSSetting.findFirst({
+    where: { areaId: checklist.areaId, name: checklist.name },
+  });
+
+  if (existing) {
+    await prisma.fiveSSetting.update({ where: { id: existing.id }, data: checklist });
+  } else {
+    await prisma.fiveSSetting.create({ data: checklist });
+  }
+}
+
 async function seedQuests() {
   const quests = [
     {
@@ -155,6 +316,7 @@ async function main() {
   await seedSkills();
   const areasByName = await seedAreas();
   await seedAuditTemplates(areasByName);
+  await seedFiveSSettings(areasByName);
   await seedQuests();
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,7 @@ import areaRoutes from "./routes/areas.js";
 import healthRouter from "./routes/health.js";
 import jobsRouter from "./routes/jobs.js";
 import gembaRouter from "./routes/gemba.js";
+import fiveSRouter from "./routes/fiveS.js";
 
 const app = express();
 const PORT = config.app.port;
@@ -46,6 +47,7 @@ app.use("/api/users", verifyToken, userRoutes);
 app.use("/api/areas", verifyToken, areaRoutes);
 app.use("/api/jobs", verifyToken, jobsRouter);
 app.use("/api/gemba", verifyToken, gembaRouter);
+app.use("/api/5s", verifyToken, fiveSRouter);
 
 app.use((req, res) => {
   res.status(404).json({

--- a/backend/src/routes/fiveS.ts
+++ b/backend/src/routes/fiveS.ts
@@ -1,0 +1,170 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { asyncHandler } from "../middleware/errorHandler.js";
+import { ValidationError } from "../middleware/errors.js";
+import { ensureUser } from "../services/gembaService.js";
+import {
+  addProblem,
+  getAuditDetail,
+  getAuditHistory,
+  startAudit,
+  submitAudit,
+} from "../services/fiveSService.js";
+import { exportAuditReport, getLeaderboard, getSetting } from "../services/fiveSDataService.js";
+
+const router = Router();
+
+const answerSchema = z.object({ value: z.enum(["yes", "no", "not_sure"]) });
+
+const submissionSchema = z.object({
+  answers: z.object({
+    sort: z.array(answerSchema),
+    order: z.array(answerSchema),
+    shine: z.array(answerSchema),
+    standardize: z.array(answerSchema),
+    sustain: z.array(answerSchema),
+  }),
+  problems: z
+    .array(
+      z.object({
+        position: z.string().min(2),
+        description: z.string().min(2),
+        screenshot: z.string().optional(),
+        category: z.string(),
+        severity: z.enum(["low", "medium", "high"]),
+      })
+    )
+    .optional()
+    .default([]),
+  timeSpent: z.number().int().positive().optional(),
+});
+
+const problemSchema = z.object({
+  position: z.string().min(2),
+  description: z.string().min(2),
+  screenshot: z.string().optional(),
+  category: z.string(),
+  severity: z.enum(["low", "medium", "high"]),
+});
+
+router.get(
+  "/settings/:areaId",
+  asyncHandler(async (req: Request, res: Response) => {
+    const areaId = Number(req.params.areaId);
+    const setting = await getSetting(areaId);
+
+    if (!setting) {
+      throw new ValidationError("No 5S checklist configured for this area");
+    }
+
+    res.json(setting);
+  })
+);
+
+router.post(
+  "/audits",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const areaId = Number(req.body.areaId);
+
+    if (!areaId) {
+      throw new ValidationError("areaId is required to start an audit");
+    }
+
+    const audit = await startAudit(user.id, areaId);
+    res.status(201).json({ audit });
+  })
+);
+
+router.get(
+  "/audits/:auditId",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const auditId = Number(req.params.auditId);
+    const audit = await getAuditDetail(auditId, user.id);
+
+    if (!audit) {
+      throw new ValidationError("Audit not found");
+    }
+
+    res.json(audit);
+  })
+);
+
+router.post(
+  "/audits/:auditId/submit",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const auditId = Number(req.params.auditId);
+
+    const parsed = submissionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new ValidationError("Invalid submission payload", parsed.error.flatten());
+    }
+
+    const result = await submitAudit(
+      auditId,
+      user.id,
+      parsed.data.answers,
+      parsed.data.problems,
+      parsed.data.timeSpent
+    );
+
+    res.json(result);
+  })
+);
+
+router.post(
+  "/audits/:auditId/problem",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const auditId = Number(req.params.auditId);
+    const parsed = problemSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      throw new ValidationError("Invalid problem payload", parsed.error.flatten());
+    }
+
+    const saved = await addProblem(auditId, user.id, parsed.data);
+    res.status(201).json(saved);
+  })
+);
+
+router.get(
+  "/audits/user/:userId",
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = await ensureUser(req.user);
+    const requestedUserId = Number(req.params.userId);
+
+    if (requestedUserId !== user.id) {
+      throw new ValidationError("You can only view your own audit history");
+    }
+
+    const audits = await getAuditHistory(user.id);
+    res.json({ audits });
+  })
+);
+
+router.get(
+  "/leaderboard",
+  asyncHandler(async (_req: Request, res: Response) => {
+    const leaderboard = await getLeaderboard();
+    res.json({ leaderboard });
+  })
+);
+
+router.get(
+  "/audits/:auditId/report",
+  asyncHandler(async (req: Request, res: Response) => {
+    const auditId = Number(req.params.auditId);
+    const report = await exportAuditReport(auditId);
+
+    if (!report) {
+      throw new ValidationError("Report not available");
+    }
+
+    res.json(report);
+  })
+);
+
+export default router;

--- a/backend/src/services/fiveSDataService.ts
+++ b/backend/src/services/fiveSDataService.ts
@@ -1,0 +1,70 @@
+import prisma from "../lib/prisma.js";
+
+export async function getSetting(areaId: number) {
+  const setting = await prisma.fiveSSetting.findFirst({
+    where: { areaId },
+  });
+
+  return setting;
+}
+
+export async function getLeaderboard() {
+  const aggregates = await prisma.fiveSAudit.groupBy({
+    by: ["userId"],
+    _avg: { totalScore: true },
+    _count: { _all: true },
+  });
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: aggregates.map((row) => row.userId) } },
+    select: { id: true, name: true, role: true, level: true, totalXp: true },
+  });
+
+  return aggregates
+    .map((row) => {
+      const user = users.find((u) => u.id === row.userId);
+      return {
+        userId: row.userId,
+        name: user?.name ?? `User ${row.userId}`,
+        role: user?.role ?? "operator",
+        level: user?.level ?? 1,
+        xp: user?.totalXp ?? 0,
+        auditCount: row._count._all,
+        averageScore: Math.round(row._avg.totalScore ?? 0),
+      };
+    })
+    .sort((a, b) => b.averageScore - a.averageScore)
+    .slice(0, 25);
+}
+
+export async function exportAuditReport(auditId: number) {
+  const audit = await prisma.fiveSAudit.findUnique({
+    where: { id: auditId },
+    include: {
+      problems: true,
+      area: true,
+      setting: true,
+      user: { select: { id: true, name: true, email: true } },
+    },
+  });
+
+  if (!audit) return null;
+
+  return {
+    id: audit.id,
+    area: audit.area.name,
+    auditor: audit.user.name,
+    score: audit.totalScore,
+    breakdown: {
+      sort: audit.sortScore,
+      order: audit.orderScore,
+      shine: audit.shineScore,
+      standardize: audit.standardizeScore,
+      sustain: audit.sustainScore,
+    },
+    problems: audit.problems,
+    mainIssue: audit.mainIssue,
+    feedback: audit.aiFeedback,
+    createdAt: audit.createdAt,
+  };
+}

--- a/backend/src/services/fiveSEvaluationService.ts
+++ b/backend/src/services/fiveSEvaluationService.ts
@@ -1,0 +1,79 @@
+import prisma from "../lib/prisma.js";
+import { FiveSProblem, FiveSAudit, Area } from "@prisma/client";
+
+const severityWeight: Record<string, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+export function identifyMainIssue(problems: FiveSProblem[]): FiveSProblem | null {
+  if (!problems.length) return null;
+
+  const sorted = [...problems].sort((a, b) => {
+    const severityDelta = (severityWeight[b.severity] ?? 0) - (severityWeight[a.severity] ?? 0);
+    if (severityDelta !== 0) return severityDelta;
+    return b.id - a.id;
+  });
+
+  return sorted[0];
+}
+
+export function generateFeedback(audit: FiveSAudit, area: Area, problems: FiveSProblem[]): string {
+  const lines: string[] = [];
+
+  if (audit.totalScore !== null && audit.totalScore !== undefined) {
+    const status = audit.totalScore >= (audit.setting?.passingScore ?? 70) ? "passed" : "needs improvement";
+    lines.push(`Audit for ${area.name} ${status}. Score ${audit.totalScore}/100.`);
+  }
+
+  if (problems.length) {
+    const topIssue = identifyMainIssue(problems);
+    if (topIssue) {
+      lines.push(`Top issue: ${topIssue.description} (${topIssue.category}, severity ${topIssue.severity}).`);
+    }
+    lines.push("Address the listed problems to boost the score next run.");
+  } else {
+    lines.push("Great job keeping the area clean—no critical problems logged.");
+  }
+
+  lines.push("Keep standard work visible and sustain daily 5S checks.");
+  return lines.join(" ");
+}
+
+export async function awardBadges(userId: number, latestScore: number) {
+  const aggregates = await prisma.fiveSAudit.aggregate({
+    where: { userId, totalScore: { not: null } },
+    _count: { _all: true },
+    _avg: { totalScore: true },
+  });
+
+  const totalAudits = aggregates._count._all;
+  const averageScore = aggregates._avg.totalScore ?? 0;
+
+  if (totalAudits >= 25 && averageScore >= 85) {
+    return "5S Master";
+  }
+
+  if (totalAudits >= 10 && averageScore >= 75) {
+    return "5S Auditor";
+  }
+
+  if (latestScore >= 70) {
+    return "5S Rookie";
+  }
+
+  return null;
+}
+
+export async function evaluateAudit(audit: FiveSAudit & { problems: FiveSProblem[]; area: Area }) {
+  const mainIssue = identifyMainIssue(audit.problems);
+  const feedback = generateFeedback(audit, audit.area, audit.problems);
+  const badge = await awardBadges(audit.userId, audit.totalScore ?? 0);
+
+  return {
+    feedback,
+    mainIssue: mainIssue?.description ?? null,
+    badge,
+  };
+}

--- a/backend/src/services/fiveSService.ts
+++ b/backend/src/services/fiveSService.ts
@@ -1,0 +1,190 @@
+import { FiveSAudit } from "@prisma/client";
+import { ValidationError, NotFoundError } from "../middleware/errors.js";
+import prisma from "../lib/prisma.js";
+import { evaluateAudit } from "./fiveSEvaluationService.js";
+
+export type FiveSAnswer = {
+  value: "yes" | "no" | "not_sure";
+};
+
+export type FiveSSubmission = {
+  sort: FiveSAnswer[];
+  order: FiveSAnswer[];
+  shine: FiveSAnswer[];
+  standardize: FiveSAnswer[];
+  sustain: FiveSAnswer[];
+};
+
+export type ProblemInput = {
+  position: string;
+  description: string;
+  screenshot?: string;
+  category: string;
+  severity: "low" | "medium" | "high";
+};
+
+export function calculateScore(answers: FiveSSubmission, problems: ProblemInput[]) {
+  const categoryScore = (items: FiveSAnswer[]) => items.filter((a) => a.value === "yes").length * 4;
+
+  const scores = {
+    sort: categoryScore(answers.sort),
+    order: categoryScore(answers.order),
+    shine: categoryScore(answers.shine),
+    standardize: categoryScore(answers.standardize),
+    sustain: categoryScore(answers.sustain),
+  };
+
+  const totalScore = Object.values(scores).reduce((sum, value) => sum + value, 0);
+
+  const problemWeight: Record<ProblemInput["severity"], number> = {
+    low: 2,
+    medium: 5,
+    high: 10,
+  };
+
+  const problemScore = -1 * problems.reduce((sum, problem) => sum + (problemWeight[problem.severity] ?? 0), 0);
+  const finalScore = Math.max(0, totalScore + problemScore);
+
+  return { scores, totalScore: finalScore };
+}
+
+export async function startAudit(userId: number, areaId: number) {
+  const setting = await prisma.fiveSSetting.findFirst({ where: { areaId } });
+  if (!setting) {
+    throw new NotFoundError("5S checklist for area");
+  }
+
+  const audit = await prisma.fiveSAudit.create({
+    data: {
+      userId,
+      areaId,
+      settingId: setting.id,
+      status: "in_progress",
+      startedAt: new Date(),
+    },
+    include: { setting: true },
+  });
+
+  return audit;
+}
+
+export async function submitAudit(
+  auditId: number,
+  userId: number,
+  answers: FiveSSubmission,
+  problems: ProblemInput[] = [],
+  timeSpent?: number
+) {
+  const audit = await prisma.fiveSAudit.findUnique({
+    where: { id: auditId },
+    include: { setting: true, area: true, problems: true },
+  });
+
+  if (!audit) {
+    throw new NotFoundError("Audit");
+  }
+
+  if (audit.userId !== userId) {
+    throw new ValidationError("You can only submit your own audits");
+  }
+
+  const { scores, totalScore } = calculateScore(answers, problems);
+  const status = totalScore >= (audit.setting.passingScore ?? 70) ? "evaluated" : "needs_improvement";
+
+  const difficultyBonus: Record<string, number> = {
+    Injection: 1.0,
+    Assembly: 1.1,
+    Painting: 1.2,
+    Warehouse: 1.3,
+  };
+
+  const difficultyKey = audit.area.name.split(" ")[0] as keyof typeof difficultyBonus;
+  const xpMultiplier =
+    (totalScore / 100) * (difficultyBonus[difficultyKey] ?? 1) * (timeSpent && timeSpent < audit.setting.timeLimit ? 1.1 : 1);
+  const xpGain = Math.round(100 * xpMultiplier);
+  const pointsGain = totalScore;
+
+  const updatedAudit = await prisma.fiveSAudit.update({
+    where: { id: auditId },
+    data: {
+      sortScore: scores.sort,
+      orderScore: scores.order,
+      shineScore: scores.shine,
+      standardizeScore: scores.standardize,
+      sustainScore: scores.sustain,
+      totalScore,
+      problemsFound: problems,
+      status,
+      completedAt: new Date(),
+      timeSpent,
+      xpGain,
+      pointsGain,
+    },
+    include: { setting: true, area: true, problems: true },
+  });
+
+  if (problems.length) {
+    const preparedProblems = problems.map((problem) => ({ ...problem, auditId }));
+    await prisma.fiveSProblem.createMany({ data: preparedProblems });
+  }
+
+  await prisma.user.update({ where: { id: userId }, data: { totalXp: { increment: xpGain } } });
+
+  const evaluated = await prisma.fiveSAudit.findUnique({
+    where: { id: auditId },
+    include: { problems: true, area: true, setting: true },
+  });
+
+  if (!evaluated) {
+    throw new NotFoundError("Audit");
+  }
+
+  const feedback = await evaluateAudit(evaluated);
+
+  const finalAudit = await prisma.fiveSAudit.update({
+    where: { id: auditId },
+    data: {
+      aiFeedback: feedback.feedback,
+      mainIssue: feedback.mainIssue ?? undefined,
+      badgeEarned: feedback.badge ?? undefined,
+    },
+    include: { problems: true, area: true, setting: true },
+  });
+
+  return finalAudit;
+}
+
+export async function getAuditDetail(auditId: number, userId: number): Promise<FiveSAudit | null> {
+  const audit = await prisma.fiveSAudit.findUnique({
+    where: { id: auditId },
+    include: { setting: true, problems: true, area: true },
+  });
+
+  if (audit && audit.userId !== userId) {
+    throw new ValidationError("You can only view your own audits");
+  }
+
+  return audit;
+}
+
+export async function getAuditHistory(userId: number) {
+  return prisma.fiveSAudit.findMany({
+    where: { userId },
+    include: { area: true, setting: true },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export async function addProblem(auditId: number, userId: number, problem: ProblemInput) {
+  const audit = await prisma.fiveSAudit.findUnique({ where: { id: auditId } });
+  if (!audit) {
+    throw new NotFoundError("Audit");
+  }
+
+  if (audit.userId !== userId) {
+    throw new ValidationError("Cannot update another user's audit");
+  }
+
+  const saved = await prisma.fiveSProblem.create({ data: { ...problem, auditId } });
+  return saved;
+}

--- a/frontend/app/(game)/gemba/5s/audit/[areaId]/page.tsx
+++ b/frontend/app/(game)/gemba/5s/audit/[areaId]/page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { fetchFiveSSetting, startFiveSAudit } from '@/lib/api/fiveS';
+import type { FiveSSetting } from '@/lib/api/fiveS';
+
+export default function AuditBriefingPage() {
+  const router = useRouter();
+  const params = useParams();
+  const areaId = Number(params?.areaId);
+  const [setting, setSetting] = useState<FiveSSetting | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const checklist = await fetchFiveSSetting(areaId);
+        setSetting(checklist);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+
+    if (areaId) {
+      load();
+    }
+  }, [areaId]);
+
+  const handleStart = async () => {
+    try {
+      setLoading(true);
+      const audit = await startFiveSAudit(areaId);
+      router.push(`/gemba/5s/audit/${audit.id}/checklist`);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card title="Audit briefing" description="Připrav se na 5S audit">
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {setting ? (
+          <div className="space-y-2 text-sm text-gray-800">
+            <p className="font-semibold">{setting.name}</p>
+            <p>Time limit: {Math.round(setting.timeLimit / 60)} min</p>
+            <p>Passing score: {setting.passingScore}</p>
+            <p className="text-gray-600">Max problems to log: {setting.maxProblems}</p>
+            <Button onClick={handleStart} disabled={loading} className="mt-3">
+              {loading ? 'Starting...' : 'Start audit'}
+            </Button>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-600">Loading checklist...</p>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/(game)/gemba/5s/audit/[auditId]/checklist/page.tsx
+++ b/frontend/app/(game)/gemba/5s/audit/[auditId]/checklist/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { fetchAudit, submitFiveSAudit } from '@/lib/api/fiveS';
+import type { FiveSAudit, FiveSProblem } from '@/lib/api/fiveS';
+
+const options: { value: 'yes' | 'no' | 'not_sure'; label: string }[] = [
+  { value: 'yes', label: 'Yes' },
+  { value: 'no', label: 'No' },
+  { value: 'not_sure', label: 'Not sure' },
+];
+
+export default function AuditChecklistPage() {
+  const params = useParams();
+  const auditId = Number(params?.auditId);
+  const router = useRouter();
+  const [audit, setAudit] = useState<FiveSAudit | null>(null);
+  const [answers, setAnswers] = useState<Record<string, { value: string }[]>>({
+    sort: [],
+    order: [],
+    shine: [],
+    standardize: [],
+    sustain: [],
+  });
+  const [problems, setProblems] = useState<FiveSProblem[]>([]);
+  const [problemDraft, setProblemDraft] = useState<FiveSProblem>({
+    position: '',
+    description: '',
+    category: 'sort',
+    severity: 'medium',
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const auditDetail = await fetchAudit(auditId);
+        setAudit(auditDetail);
+        if (auditDetail.setting) {
+          setAnswers({
+            sort: auditDetail.setting.sortCriteria.map(() => ({ value: 'yes' })),
+            order: auditDetail.setting.orderCriteria.map(() => ({ value: 'yes' })),
+            shine: auditDetail.setting.shineCriteria.map(() => ({ value: 'yes' })),
+            standardize: auditDetail.setting.standardizeCriteria.map(() => ({ value: 'yes' })),
+            sustain: auditDetail.setting.sustainCriteria.map(() => ({ value: 'yes' })),
+          });
+        }
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+
+    if (auditId) load();
+  }, [auditId]);
+
+  const updateAnswer = (phase: string, index: number, value: 'yes' | 'no' | 'not_sure') => {
+    setAnswers((prev) => {
+      const updated = [...(prev[phase] || [])];
+      updated[index] = { value };
+      return { ...prev, [phase]: updated };
+    });
+  };
+
+  const addProblem = () => {
+    if (!problemDraft.position || !problemDraft.description) return;
+    setProblems((prev) => [...prev, { ...problemDraft }]);
+    setProblemDraft({ position: '', description: '', category: 'sort', severity: 'medium' });
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const result = await submitFiveSAudit(auditId, { answers, problems });
+      router.push(`/gemba/5s/audit/${result.id}/result`);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const renderPhase = (key: string, title: string, questions: any[]) => (
+    <Card key={key} title={title} description="Odpověz na otázky">
+      <div className="space-y-3">
+        {questions.map((q, index) => (
+          <div key={q.id} className="space-y-1 rounded-md border border-gray-200 p-3 text-sm">
+            <p className="font-semibold text-gray-900">{q.question}</p>
+            <p className="text-xs text-gray-600">{q.hint}</p>
+            <div className="flex gap-2">
+              {options.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => updateAnswer(key, index, opt.value)}
+                  className={`rounded-full border px-3 py-1 text-xs ${
+                    answers[key]?.[index]?.value === opt.value ? 'bg-blue-600 text-white' : 'border-gray-200'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">5S Checklist</h1>
+          <p className="text-sm text-gray-600">Audit #{auditId}</p>
+        </div>
+        <Button onClick={handleSubmit} disabled={!audit}>
+          Submit audit
+        </Button>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {audit?.setting ? (
+        <div className="space-y-3">
+          {renderPhase('sort', 'Sort (Třídění)', audit.setting.sortCriteria)}
+          {renderPhase('order', 'Set in Order (Uspořádání)', audit.setting.orderCriteria)}
+          {renderPhase('shine', 'Shine (Čistota)', audit.setting.shineCriteria)}
+          {renderPhase('standardize', 'Standardize', audit.setting.standardizeCriteria)}
+          {renderPhase('sustain', 'Sustain', audit.setting.sustainCriteria)}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-600">Loading checklist...</p>
+      )}
+
+      <Card title="Problems" description="Přidej nalezené problémy">
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="space-y-2 text-sm">
+            <label className="block text-gray-700">Position</label>
+            <input
+              value={problemDraft.position}
+              onChange={(e) => setProblemDraft({ ...problemDraft, position: e.target.value })}
+              className="w-full rounded-md border px-3 py-2 text-sm"
+            />
+            <label className="block text-gray-700">Category</label>
+            <select
+              value={problemDraft.category}
+              onChange={(e) => setProblemDraft({ ...problemDraft, category: e.target.value })}
+              className="w-full rounded-md border px-3 py-2 text-sm"
+            >
+              <option value="sort">Sort</option>
+              <option value="order">Set in order</option>
+              <option value="shine">Shine</option>
+              <option value="standardize">Standardize</option>
+              <option value="sustain">Sustain</option>
+            </select>
+            <label className="block text-gray-700">Severity</label>
+            <select
+              value={problemDraft.severity}
+              onChange={(e) => setProblemDraft({ ...problemDraft, severity: e.target.value as any })}
+              className="w-full rounded-md border px-3 py-2 text-sm"
+            >
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+          </div>
+          <div className="space-y-2 text-sm">
+            <label className="block text-gray-700">Description</label>
+            <textarea
+              value={problemDraft.description}
+              onChange={(e) => setProblemDraft({ ...problemDraft, description: e.target.value })}
+              className="h-24 w-full rounded-md border px-3 py-2 text-sm"
+            />
+            <Button type="button" onClick={addProblem} className="mt-2">
+              Add problem
+            </Button>
+          </div>
+        </div>
+
+        {problems.length > 0 && (
+          <div className="mt-3 space-y-2 text-sm">
+            {problems.map((problem, index) => (
+              <div key={index} className="rounded-md border border-gray-200 px-3 py-2">
+                <p className="font-semibold">{problem.description}</p>
+                <p className="text-xs text-gray-600">
+                  {problem.position} · {problem.category} · {problem.severity}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/(game)/gemba/5s/audit/[auditId]/problems/page.tsx
+++ b/frontend/app/(game)/gemba/5s/audit/[auditId]/problems/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function ProblemsPlaceholderPage() {
+  return (
+    <div className="space-y-3">
+      <h1 className="text-2xl font-bold">Problem capture</h1>
+      <p className="text-sm text-gray-700">
+        Přidávání problémů je dostupné přímo v checklistu. Vrať se a přidej issues před odesláním auditu.
+      </p>
+      <Link href="/gemba/5s" className="text-blue-700">
+        Zpět na 5S hub
+      </Link>
+    </div>
+  );
+}

--- a/frontend/app/(game)/gemba/5s/audit/[auditId]/result/page.tsx
+++ b/frontend/app/(game)/gemba/5s/audit/[auditId]/result/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Card } from '@/components/ui/card';
+import { fetchAudit } from '@/lib/api/fiveS';
+import type { FiveSAudit } from '@/lib/api/fiveS';
+
+export default function AuditResultPage() {
+  const params = useParams();
+  const auditId = Number(params?.auditId);
+  const [audit, setAudit] = useState<FiveSAudit | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const detail = await fetchAudit(auditId);
+        setAudit(detail);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+
+    if (auditId) load();
+  }, [auditId]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">✅ Audit complete</h1>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {audit ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          <Card title="Score" description={audit.setting?.name ?? '5S Audit'}>
+            <p className="text-3xl font-bold text-blue-700">{audit.totalScore ?? '—'}/100</p>
+            <p className="text-sm text-gray-600">Status: {audit.status}</p>
+            <p className="text-sm text-gray-600">Time: {audit.timeSpent ? `${audit.timeSpent}s` : 'n/a'}</p>
+            <p className="text-sm text-gray-600">XP: +{audit.xpGain}</p>
+            <p className="text-sm text-gray-600">Points: +{audit.pointsGain}</p>
+            {audit.badgeEarned && <p className="text-sm text-emerald-700">Badge: {audit.badgeEarned}</p>}
+          </Card>
+          <Card title="Breakdown" description="Kategorie">
+            <ul className="space-y-1 text-sm text-gray-800">
+              <li>Sort: {audit.sortScore ?? '—'}/20</li>
+              <li>Set in order: {audit.orderScore ?? '—'}/20</li>
+              <li>Shine: {audit.shineScore ?? '—'}/20</li>
+              <li>Standardize: {audit.standardizeScore ?? '—'}/20</li>
+              <li>Sustain: {audit.sustainScore ?? '—'}/20</li>
+            </ul>
+          </Card>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-600">Loading audit...</p>
+      )}
+
+      {audit?.mainIssue && (
+        <Card title="Top issue" description="Největší problém">
+          <p className="text-sm text-gray-800">{audit.mainIssue}</p>
+        </Card>
+      )}
+
+      {audit?.aiFeedback && (
+        <Card title="AI feedback" description="Doporučení">
+          <p className="text-sm text-gray-800">{audit.aiFeedback}</p>
+        </Card>
+      )}
+
+      {audit?.problems && audit.problems.length > 0 && (
+        <Card title="Logged problems" description="Zachycené issue">
+          <div className="space-y-2 text-sm text-gray-800">
+            {audit.problems.map((problem) => (
+              <div key={problem.id} className="rounded-md border border-gray-200 px-3 py-2">
+                <p className="font-semibold">{problem.description}</p>
+                <p className="text-xs text-gray-600">
+                  {problem.position} · {problem.category} · {problem.severity}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(game)/gemba/5s/history/page.tsx
+++ b/frontend/app/(game)/gemba/5s/history/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+import { fetchAuditHistory } from '@/lib/api/fiveS';
+import { useAuth } from '@/lib/auth-context';
+
+export default function FiveSHistoryPage() {
+  const { user } = useAuth();
+  const [audits, setAudits] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user) return;
+      try {
+        const history = await fetchAuditHistory(user.id);
+        setAudits(history.audits ?? []);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+
+    load();
+  }, [user]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">My 5S audits</h1>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div className="space-y-2">
+        {audits.map((audit) => (
+          <Card key={audit.id} title={audit.setting?.name ?? '5S audit'} description={audit.area?.name}>
+            <div className="flex items-center justify-between text-sm text-gray-800">
+              <div>
+                <p>Score: {audit.totalScore ?? '—'}/100</p>
+                <p>Status: {audit.status}</p>
+              </div>
+              <Link href={`/gemba/5s/audit/${audit.id}/result`} className="text-blue-700">
+                View result
+              </Link>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(game)/gemba/5s/leaderboard/page.tsx
+++ b/frontend/app/(game)/gemba/5s/leaderboard/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { fetchFiveSLeaderboard } from '@/lib/api/fiveS';
+
+export default function FiveSLeaderboardPage() {
+  const [entries, setEntries] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const response = await fetchFiveSLeaderboard();
+        setEntries(response.leaderboard ?? []);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+
+    load();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">5S Leaderboard</h1>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <Card title="Top auditors" description="Podle průměrného skóre">
+        <div className="space-y-2 text-sm text-gray-800">
+          {entries.map((entry, index) => (
+            <div key={entry.userId} className="flex items-center justify-between rounded-md border border-gray-100 px-3 py-2">
+              <div>
+                <p className="font-semibold text-gray-900">
+                  {index + 1}. {entry.name}
+                </p>
+                <p className="text-xs text-gray-600">Audits: {entry.auditCount} · Avg: {entry.averageScore}</p>
+              </div>
+              <span className="text-blue-700">{entry.xp} XP</span>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/(game)/gemba/5s/page.tsx
+++ b/frontend/app/(game)/gemba/5s/page.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { fetchAreas } from '@/lib/api/gemba';
+import { fetchFiveSLeaderboard, fetchFiveSSetting, fetchAuditHistory } from '@/lib/api/fiveS';
+import type { FiveSSetting } from '@/lib/api/fiveS';
+import { useAuth } from '@/lib/auth-context';
+
+export default function FiveSHubPage() {
+  const { user } = useAuth();
+  const [areas, setAreas] = useState<{ id: number; name: string; locked?: boolean }[]>([]);
+  const [selectedArea, setSelectedArea] = useState<number | null>(null);
+  const [setting, setSetting] = useState<FiveSSetting | null>(null);
+  const [leaderboard, setLeaderboard] = useState<any[]>([]);
+  const [history, setHistory] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const areaData = await fetchAreas();
+        setAreas(areaData);
+        const areaId = areaData.find((a) => !a.locked)?.id ?? areaData[0]?.id;
+        if (areaId) {
+          setSelectedArea(areaId);
+          const checklist = await fetchFiveSSetting(areaId);
+          setSetting(checklist);
+        }
+        if (user) {
+          const historyResponse = await fetchAuditHistory(user.id);
+          setHistory(historyResponse.audits ?? []);
+        }
+        const leaderboardResponse = await fetchFiveSLeaderboard();
+        setLeaderboard(leaderboardResponse.leaderboard ?? []);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+
+    load();
+  }, [user]);
+
+  const recentAudit = useMemo(() => history[0], [history]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">🧹 5S Audit Hub</h1>
+          <p className="text-sm text-gray-600">Spusť rychlý 5S audit a sleduj svůj progres.</p>
+        </div>
+        {selectedArea && (
+          <Link href={`/gemba/5s/audit/${selectedArea}`} className="inline-flex">
+            <Button>Start audit</Button>
+          </Link>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card title="Select area" description="Vyber pracoviště pro audit">
+          <div className="space-y-2">
+            {areas.map((area) => (
+              <button
+                key={area.id}
+                className={`flex w-full items-center justify-between rounded-lg border px-3 py-2 text-left text-sm ${
+                  selectedArea === area.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
+                } ${area.locked ? 'opacity-50' : ''}`}
+                disabled={area.locked}
+                onClick={async () => {
+                  setSelectedArea(area.id);
+                  try {
+                    const checklist = await fetchFiveSSetting(area.id);
+                    setSetting(checklist);
+                  } catch (err) {
+                    setError((err as Error).message);
+                  }
+                }}
+              >
+                <span>{area.name}</span>
+                {area.locked ? <span className="text-xs text-gray-500">Locked</span> : <span>➡️</span>}
+              </button>
+            ))}
+          </div>
+        </Card>
+
+        <Card title="Checklist preview" description="Poslední načtený checklist">
+          {setting ? (
+            <div className="space-y-2 text-sm text-gray-800">
+              <p className="font-semibold">{setting.name}</p>
+              <p>Time limit: {Math.round(setting.timeLimit / 60)} min</p>
+              <p>Passing score: {setting.passingScore}</p>
+              <p className="text-gray-600">Otázky: {setting.sortCriteria.length * 5}+</p>
+              <Link href={`/gemba/5s/audit/${selectedArea ?? setting.areaId}`} className="text-blue-700">
+                View briefing ↗
+              </Link>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-600">No checklist found for this area.</p>
+          )}
+        </Card>
+
+        <Card title="Recent audit" description="Tvůj poslední výsledek">
+          {recentAudit ? (
+            <div className="space-y-2 text-sm text-gray-800">
+              <p className="font-semibold">{recentAudit.area?.name ?? 'Area'}</p>
+              <p>Score: {recentAudit.totalScore ?? '—'}/100</p>
+              <p>Status: {recentAudit.status}</p>
+              <Link href={`/gemba/5s/audit/${recentAudit.id}/result`} className="text-blue-700">
+                Detail výsledku
+              </Link>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-600">Ještě nemáš žádný 5S audit.</p>
+          )}
+        </Card>
+      </div>
+
+      <Card title="Leaderboard" description="Top 5S auditoři">
+        <div className="space-y-2">
+          {leaderboard.slice(0, 5).map((entry, index) => (
+            <div key={entry.userId} className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-sm">
+              <div>
+                <p className="font-semibold text-gray-900">
+                  {index + 1}. {entry.name}
+                </p>
+                <p className="text-xs text-gray-600">Audits: {entry.auditCount} · Avg: {entry.averageScore}</p>
+              </div>
+              <span className="text-blue-700">{entry.xp} XP</span>
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 text-right text-sm">
+          <Link href="/gemba/5s/leaderboard" className="text-blue-700">
+            View full leaderboard
+          </Link>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/lib/api/fiveS.ts
+++ b/frontend/lib/api/fiveS.ts
@@ -1,0 +1,175 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+
+function getAuthToken(): string {
+  if (typeof window === 'undefined') return '';
+  return localStorage.getItem('token') || '';
+}
+
+export type FiveSQuestion = { id: number; question: string; hint?: string; points?: number };
+
+export type FiveSSetting = {
+  id: number;
+  name: string;
+  areaId: number;
+  timeLimit: number;
+  maxProblems: number;
+  maxScore: number;
+  passingScore: number;
+  sortCriteria: FiveSQuestion[];
+  orderCriteria: FiveSQuestion[];
+  shineCriteria: FiveSQuestion[];
+  standardizeCriteria: FiveSQuestion[];
+  sustainCriteria: FiveSQuestion[];
+};
+
+export type FiveSProblem = {
+  id?: number;
+  position: string;
+  description: string;
+  screenshot?: string;
+  category: string;
+  severity: 'low' | 'medium' | 'high';
+};
+
+export type FiveSAudit = {
+  id: number;
+  areaId: number;
+  settingId: number;
+  status: string;
+  sortScore?: number | null;
+  orderScore?: number | null;
+  shineScore?: number | null;
+  standardizeScore?: number | null;
+  sustainScore?: number | null;
+  totalScore?: number | null;
+  problemsFound?: FiveSProblem[];
+  aiFeedback?: string | null;
+  mainIssue?: string | null;
+  xpGain: number;
+  pointsGain: number;
+  badgeEarned?: string | null;
+  completedAt?: string | null;
+  timeSpent?: number | null;
+  setting?: FiveSSetting;
+  problems?: FiveSProblem[];
+};
+
+export async function fetchFiveSSetting(areaId: number): Promise<FiveSSetting> {
+  const response = await fetch(`${API_BASE}/5s/settings/${areaId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load 5S setting');
+  }
+
+  return response.json();
+}
+
+export async function startFiveSAudit(areaId: number) {
+  const response = await fetch(`${API_BASE}/5s/audits`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    body: JSON.stringify({ areaId }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to start audit');
+  }
+
+  const data = await response.json();
+  return data.audit as FiveSAudit;
+}
+
+export async function fetchAudit(auditId: number): Promise<FiveSAudit> {
+  const response = await fetch(`${API_BASE}/5s/audits/${auditId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load audit');
+  }
+
+  return response.json();
+}
+
+export async function submitFiveSAudit(auditId: number, payload: {
+  answers: Record<string, { value: string }[]>;
+  problems: FiveSProblem[];
+  timeSpent?: number;
+}): Promise<FiveSAudit> {
+  const response = await fetch(`${API_BASE}/5s/audits/${auditId}/submit`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to submit audit');
+  }
+
+  return response.json();
+}
+
+export async function fetchAuditHistory(userId: number) {
+  const response = await fetch(`${API_BASE}/5s/audits/user/${userId}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load history');
+  }
+
+  return response.json();
+}
+
+export async function fetchFiveSLeaderboard() {
+  const response = await fetch(`${API_BASE}/5s/leaderboard`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load leaderboard');
+  }
+
+  return response.json();
+}
+
+export async function addProblemToAudit(auditId: number, problem: FiveSProblem) {
+  const response = await fetch(`${API_BASE}/5s/audits/${auditId}/problem`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getAuthToken()}`,
+    },
+    body: JSON.stringify(problem),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to add problem');
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add Prisma models, migration, and seed data for 5S audit settings, audits, and problems
- implement 5S service layer and secured API routes for starting, submitting, and viewing audits plus leaderboard
- introduce frontend 5S hub, checklist flow, results, history, and leaderboard pages with API client helpers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393f181a1c83309291b434e67fa76e)