### PR TITLE
Add AI vision analysis route and service stubs

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import jobsRouter from "./routes/jobs.js";
 import gembaRouter from "./routes/gemba.js";
 import fiveSRouter from "./routes/fiveS.js";
 import problemSolvingRouter from "./routes/problemSolving.js";
+import visionRouter from "./routes/vision.js";
 
 const app = express();
 const PORT = config.app.port;
@@ -50,6 +51,7 @@ app.use("/api/jobs", verifyToken, jobsRouter);
 app.use("/api/gemba", verifyToken, gembaRouter);
 app.use("/api/5s", verifyToken, fiveSRouter);
 app.use("/api/problem-solving", verifyToken, problemSolvingRouter);
+app.use("/api", verifyToken, visionRouter);
 
 app.use((req, res) => {
   res.status(404).json({

--- a/backend/src/routes/vision.ts
+++ b/backend/src/routes/vision.ts
@@ -1,0 +1,37 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { asyncHandler } from "../middleware/errorHandler.js";
+import { ValidationError } from "../middleware/errors.js";
+import { geminiVisionService } from "../services/geminiVisionService.js";
+
+const router = Router();
+
+const analyzeSchema = z.object({
+  photoBase64: z.string().min(1, "photoBase64 is required"),
+  context: z.enum(["PROBLEM_SOLVING", "5S"]),
+  contextDescription: z.string().optional(),
+});
+
+router.post(
+  "/ai/vision/analyze",
+  asyncHandler(async (req: Request, res: Response) => {
+    const payload = analyzeSchema.parse(req.body);
+
+    if (!req.user) {
+      throw new ValidationError("Unauthorized");
+    }
+
+    const analysis = await geminiVisionService.analyzePhoto(
+      payload.photoBase64,
+      payload.context,
+      payload.contextDescription
+    );
+
+    res.json({
+      analysis,
+      message: "Vision analysis completed",
+    });
+  })
+);
+
+export default router;

--- a/backend/src/services/geminiVisionService.ts
+++ b/backend/src/services/geminiVisionService.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from "crypto";
+
+export type VisionContext = "PROBLEM_SOLVING" | "5S";
+
+export interface VisionAnalysisResult {
+  detectedProblems: Array<{
+    type: string;
+    severity: string;
+    location?: string;
+  }>;
+  suggestedCauses: Array<{
+    category: string;
+    cause: string;
+    confidence: number;
+  }>;
+  insights: string;
+  recommendations: string[];
+  referenceId: string;
+}
+
+export class GeminiVisionService {
+  async analyzePhoto(
+    base64Image: string,
+    context: VisionContext,
+    problemDescription?: string
+  ): Promise<VisionAnalysisResult> {
+    if (!base64Image) {
+      throw new Error("Photo is required for analysis");
+    }
+
+    const referenceId = randomUUID();
+
+    if (context === "5S") {
+      return {
+        detectedProblems: [
+          { type: "Unsorted items", severity: "medium", location: "Workbench" },
+          { type: "Labeling gaps", severity: "low", location: "Storage bins" },
+        ],
+        suggestedCauses: [
+          { category: "SET IN ORDER", cause: "Tools not returned to home", confidence: 0.68 },
+          { category: "SUSTAIN", cause: "Standards not reinforced", confidence: 0.54 },
+        ],
+        insights:
+          "Surface-level 5S gaps detected. Cleaning and labeling improvements should reduce search time.",
+        recommendations: [
+          "Add clear labels for all storage bins",
+          "Schedule quick shine at end of shift",
+          "Reinforce daily audit checklist",
+        ],
+        referenceId,
+      };
+    }
+
+    return {
+      detectedProblems: [
+        { type: "WIP build-up", severity: "high", location: "Station 3" },
+        { type: "Operator waiting", severity: "medium", location: "Feeder lane" },
+      ],
+      suggestedCauses: [
+        { category: "METHODS", cause: "Unbalanced schedule", confidence: 0.76 },
+        { category: "MACHINES", cause: "Equipment cycle time variance", confidence: 0.41 },
+        { category: "PEOPLE", cause: "Limited cross-training", confidence: 0.33 },
+      ],
+      insights:
+        problemDescription?.slice(0, 160) ||
+        "Potential overproduction and flow imbalance detected. Consider rebalancing takt time and introducing FIFO controls.",
+      recommendations: [
+        "Capture real-time photo evidence for the Ishikawa diagram",
+        "Validate production schedule against demand",
+        "Introduce buffer limits before Station 3",
+      ],
+      referenceId,
+    };
+  }
+}
+
+export const geminiVisionService = new GeminiVisionService();


### PR DESCRIPTION
## Summary
- add a Gemini vision service stub that returns structured analysis results for problem solving and 5S contexts
- expose a protected `/api/ai/vision/analyze` endpoint with validation to call the vision service
- register the new vision route with the main API router

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated leaderboard, fiveS, gemba, and problem-solving services)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693943934ee483309350bac345c18a1c)