### PR TITLE
Fix quest routes to handle string IDs

### DIFF
--- a/backend/src/routes/quests.ts
+++ b/backend/src/routes/quests.ts
@@ -31,7 +31,7 @@ router.get(
     const myQuests = await prisma.userQuest.findMany({
       where: { userId: req.user.userId },
       include: { quest: true, submissions: true },
-      orderBy: { assignedAt: "desc" },
+      orderBy: { createdAt: "desc" },
     });
 
     return res.json(myQuests);
@@ -42,7 +42,7 @@ router.get(
 router.post(
   "/assign",
   asyncHandler(async (req: Request, res: Response) => {
-    const { questId } = req.body as { questId?: number };
+    const { questId } = req.body as { questId?: string };
 
     if (!req.user) {
       throw new UnauthorizedError();
@@ -78,8 +78,8 @@ router.post(
       throw new UnauthorizedError();
     }
 
-    const questId = Number(req.params.id);
-    if (Number.isNaN(questId)) {
+    const questId = req.params.id;
+    if (!questId || questId.length === 0) {
       throw new ValidationError("Invalid quest id", { questId: req.params.id });
     }
 
@@ -112,9 +112,9 @@ router.post(
 router.get(
   "/:id",
   asyncHandler(async (req: Request, res: Response) => {
-    const questId = Number(req.params.id);
+    const questId = req.params.id;
 
-    if (Number.isNaN(questId)) {
+    if (!questId || questId.length === 0) {
       throw new ValidationError("Invalid quest id", { questId: req.params.id });
     }
 


### PR DESCRIPTION
## Summary

Update quest route handlers to work with string-based quest IDs (CUID format) introduced in PR #58.

### Changes

- ✅ Convert `questId` type from `number` to `string` in `/assign` endpoint
- ✅ Replace `Number(req.params.id)` with direct string usage in `/:id/accept` endpoint
- ✅ Replace `Number(req.params.id)` with direct string usage in `/:id` (detail) endpoint
- ✅ Update validation: `Number.isNaN()` → `!questId || questId.length === 0`
- ✅ Fix UserQuest ordering: `assignedAt` → `createdAt` (field was renamed in PR #58)

### Testing

- ✅ `npm run build` passes
- ✅ TypeScript strict mode compliant
- ✅ All quest routes handle string IDs correctly

### Acceptance Criteria

- [x] All Number() conversions removed from quest ID handling
- [x] String ID validation is proper (length check instead of NaN)
- [x] OrderBy clause uses correct UserQuest field (createdAt)
- [x] Type annotations updated (questId?: string)
- [x] Build succeeds without errors
