### PR TITLE
feat: add quest list page with filters

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
 import { AuthProvider } from '@/lib/auth-context';
-import { ReactNode } from 'react';
 
 export function Providers({ children }: { children: ReactNode }) {
-  return <AuthProvider>{children}</AuthProvider>;
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
 }

--- a/frontend/app/quests/page.tsx
+++ b/frontend/app/quests/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useQuests } from '@/hooks/useQuests';
+import { QuestCard } from '@/components/QuestCard';
+import { QuestFilters } from '@/components/QuestFilters';
+import { Quest, Difficulty, LeanConcept } from '@/types/quest';
+
+export default function QuestsPage() {
+  const { data: quests = [], isLoading, error } = useQuests();
+  const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty | 'all'>('all');
+  const [selectedConcept, setSelectedConcept] = useState<LeanConcept | 'all'>('all');
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredQuests = useMemo(() => {
+    return quests.filter((quest: Quest) => {
+      const matchesDifficulty = selectedDifficulty === 'all' || quest.difficulty === selectedDifficulty;
+      const matchesConcept = selectedConcept === 'all' || quest.leanConcept === selectedConcept;
+      const matchesSearch =
+        quest.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        quest.description.toLowerCase().includes(searchTerm.toLowerCase());
+
+      return matchesDifficulty && matchesConcept && matchesSearch;
+    });
+  }, [quests, selectedDifficulty, selectedConcept, searchTerm]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading quests...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center text-red-600">
+          <p className="text-lg font-bold mb-2">Failed to load quests</p>
+          <p className="text-sm">{error instanceof Error ? error.message : 'Unknown error'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold text-gray-900 mb-2">🎮 Quests</h1>
+          <p className="text-gray-600">
+            Choose a quest and start learning Lean! ({filteredQuests.length} available)
+          </p>
+        </div>
+
+        {/* Search Bar */}
+        <div className="mb-8">
+          <input
+            type="text"
+            placeholder="Search quests by title or description..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          />
+        </div>
+
+        {/* Filters */}
+        <QuestFilters
+          selectedDifficulty={selectedDifficulty}
+          selectedConcept={selectedConcept}
+          onDifficultyChange={setSelectedDifficulty}
+          onConceptChange={setSelectedConcept}
+        />
+
+        {/* Quests Grid */}
+        {filteredQuests.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredQuests.map((quest: Quest) => (
+              <QuestCard key={quest.id} quest={quest} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <p className="text-gray-600 text-lg">No quests found matching your criteria</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/QuestCard.tsx
+++ b/frontend/components/QuestCard.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import Link from 'next/link';
+import { Quest, Difficulty } from '@/types/quest';
+
+interface QuestCardProps {
+  quest: Quest;
+}
+
+export function QuestCard({ quest }: QuestCardProps) {
+  const difficultyConfig: Record<
+    Difficulty,
+    { color: string; label: string; bgColor: string }
+  > = {
+    easy: {
+      color: 'text-green-600',
+      label: 'Easy',
+      bgColor: 'bg-green-100',
+    },
+    medium: {
+      color: 'text-yellow-600',
+      label: 'Medium',
+      bgColor: 'bg-yellow-100',
+    },
+    hard: {
+      color: 'text-red-600',
+      label: 'Hard',
+      bgColor: 'bg-red-100',
+    },
+  };
+
+  const difficulty = difficultyConfig[quest.difficulty];
+
+  return (
+    <Link href={`/quests/${quest.id}`}>
+      <div className="h-full p-6 bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow cursor-pointer">
+        {/* Header */}
+        <div className="flex items-start justify-between mb-4">
+          <h3 className="text-lg font-bold text-gray-900 flex-1 pr-2">
+            {quest.title}
+          </h3>
+          <span
+            className={`px-3 py-1 text-sm font-semibold rounded-full whitespace-nowrap ${difficulty.bgColor} ${difficulty.color}`}
+          >
+            {difficulty.label}
+          </span>
+        </div>
+
+        {/* Lean Concept Badge */}
+        <div className="mb-4">
+          <span className="inline-block px-2 py-1 text-xs font-medium text-blue-700 bg-blue-100 rounded">
+            {quest.leanConcept}
+          </span>
+        </div>
+
+        {/* Description */}
+        <p className="text-sm text-gray-600 mb-4 line-clamp-2">
+          {quest.description}
+        </p>
+
+        {/* Objectives Preview */}
+        <div className="mb-4">
+          <p className="text-xs font-semibold text-gray-700 mb-2">Objectives:</p>
+          <ul className="text-xs text-gray-600 space-y-1">
+            {(Array.isArray(quest.objectives)
+              ? quest.objectives
+              : JSON.parse(quest.objectives)
+            ).slice(0, 2).map((obj, idx) => (
+              <li key={idx} className="flex items-start">
+                <span className="mr-2">•</span>
+                <span className="line-clamp-1">{obj}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Footer: XP + Time */}
+        <div className="flex items-center justify-between pt-4 border-t border-gray-200">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-bold text-amber-600">⭐</span>
+              <span className="text-sm font-semibold text-gray-700">
+                {quest.xpReward} XP
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="text-sm">⏱️</span>
+              <span className="text-sm text-gray-600">
+                {quest.timeEstimate} min
+              </span>
+            </div>
+          </div>
+
+          {quest.skillUnlock && (
+            <div className="text-xs font-medium text-purple-600 bg-purple-50 px-2 py-1 rounded">
+              🔓 Unlock
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/frontend/components/QuestFilters.tsx
+++ b/frontend/components/QuestFilters.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Difficulty, LeanConcept } from '@/types/quest';
+
+interface QuestFiltersProps {
+  selectedDifficulty: Difficulty | 'all';
+  selectedConcept: LeanConcept | 'all';
+  onDifficultyChange: (difficulty: Difficulty | 'all') => void;
+  onConceptChange: (concept: LeanConcept | 'all') => void;
+}
+
+const DIFFICULTIES: Array<Difficulty | 'all'> = ['all', 'easy', 'medium', 'hard'];
+const CONCEPTS: Array<LeanConcept | 'all'> = ['all', '5S', 'Kaizen', 'ProblemSolving', 'StandardWork', 'Gemba'];
+
+export function QuestFilters({
+  selectedDifficulty,
+  selectedConcept,
+  onDifficultyChange,
+  onConceptChange,
+}: QuestFiltersProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 mb-8">
+      <h2 className="text-lg font-bold text-gray-900 mb-4">Filters</h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Difficulty Filter */}
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-3">
+            Difficulty
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {DIFFICULTIES.map((diff) => (
+              <button
+                key={diff}
+                onClick={() => onDifficultyChange(diff)}
+                className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                  selectedDifficulty === diff
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {diff === 'all' ? 'All Levels' : diff.charAt(0).toUpperCase() + diff.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Lean Concept Filter */}
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-3">
+            Lean Concept
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {CONCEPTS.map((concept) => (
+              <button
+                key={concept}
+                onClick={() => onConceptChange(concept)}
+                className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                  selectedConcept === concept
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {concept === 'all' ? 'All Topics' : concept}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useQuests.ts
+++ b/frontend/hooks/useQuests.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Quest } from '@/types/quest';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+
+export function useQuests() {
+  return useQuery({
+    queryKey: ['quests'],
+    queryFn: async () => {
+      const response = await fetch(`${API_BASE}/quests`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch quests');
+      }
+      return response.json() as Promise<Quest[]>;
+    },
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+}
+
+export function useQuestById(questId: string) {
+  return useQuery({
+    queryKey: ['quests', questId],
+    queryFn: async () => {
+      const response = await fetch(`${API_BASE}/quests/${questId}`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch quest');
+      }
+      return response.json() as Promise<Quest>;
+    },
+    enabled: !!questId,
+  });
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.66.0",
     "axios": "^1.6.8",
     "clsx": "^2.1.1",
     "lucide-react": "^0.378.0",
@@ -19,6 +20,7 @@
     "sonner": "^1.5.0"
   },
   "devDependencies": {
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import lineClamp from '@tailwindcss/line-clamp';
 
 const config: Config = {
   content: [
@@ -17,7 +18,7 @@ const config: Config = {
       }
     }
   },
-  plugins: []
+  plugins: [lineClamp]
 };
 
 export default config;

--- a/frontend/types/quest.ts
+++ b/frontend/types/quest.ts
@@ -1,18 +1,39 @@
-export type Quest = {
-  id: number;
+export interface Quest {
+  id: string;
+  code: string;
   title: string;
   description: string;
-  baseXp: number;
-  briefText?: string | null;
-  leanConcept?: string | null;
+  leanConcept: string;
+  story: string;
+  objectives: string[];
+  difficulty: 'easy' | 'medium' | 'hard';
+  xpReward: number;
+  timeEstimate: number;
+  skillUnlock?: string | null;
   isActive: boolean;
-};
+  createdAt: string;
+  updatedAt: string;
+  // Legacy fields preserved for backwards compatibility
+  baseXp?: number;
+  briefText?: string | null;
+}
 
-export type UserQuest = {
-  id: number;
-  userId: number;
-  questId: number;
-  status: "not_started" | "in_progress" | "evaluated" | "completed" | "abandoned";
-  acceptedAt?: Date;
-  completedAt?: Date;
-};
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+export type LeanConcept =
+  | '5S'
+  | 'Kaizen'
+  | 'ProblemSolving'
+  | 'StandardWork'
+  | 'Gemba';
+
+export interface UserQuest {
+  id: string;
+  userId: string;
+  questId: string;
+  status: 'not_started' | 'in_progress' | 'completed';
+  xpEarned?: number;
+  completedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- add quest typing updates and React Query hooks for quests
- implement quest list page with search, difficulty, and concept filters plus responsive cards
- enable React Query provider and Tailwind line-clamp utility for the new UI

## Testing
- Not run (npm registry access blocked in environment, npm install returned 403)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7a1d04ac83308f2aa508425dd26d)