### PR TITLE
Add quest submission flow with modal and Zustand store

### DIFF
--- a/frontend/app/quests/page.tsx
+++ b/frontend/app/quests/page.tsx
@@ -1,16 +1,27 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuests } from '@/hooks/useQuests';
 import { QuestCard } from '@/components/QuestCard';
 import { QuestFilters } from '@/components/QuestFilters';
 import { Quest, Difficulty, LeanConcept } from '@/types/quest';
+import { QuestDetailModal } from '@/src/components/QuestDetailModal';
+import { useSubmissionStore } from '@/src/store/submissionStore';
 
 export default function QuestsPage() {
   const { data: quests = [], isLoading, error } = useQuests();
   const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty | 'all'>('all');
   const [selectedConcept, setSelectedConcept] = useState<LeanConcept | 'all'>('all');
   const [searchTerm, setSearchTerm] = useState('');
+  const [selectedQuest, setSelectedQuest] = useState<Quest | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const resetSubmissionForm = useSubmissionStore((state) => state.resetForm);
+
+  const handleQuestClick = (quest: Quest) => {
+    resetSubmissionForm();
+    setSelectedQuest(quest);
+    setIsModalOpen(true);
+  };
 
   const filteredQuests = useMemo(() => {
     return quests.filter((quest: Quest) => {
@@ -80,7 +91,7 @@ export default function QuestsPage() {
         {filteredQuests.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {filteredQuests.map((quest: Quest) => (
-              <QuestCard key={quest.id} quest={quest} />
+              <QuestCard key={quest.id} quest={quest} onSelect={handleQuestClick} />
             ))}
           </div>
         ) : (
@@ -89,6 +100,16 @@ export default function QuestsPage() {
           </div>
         )}
       </div>
+
+      <QuestDetailModal
+        quest={selectedQuest}
+        isOpen={isModalOpen}
+        onClose={() => {
+          resetSubmissionForm();
+          setIsModalOpen(false);
+          setSelectedQuest(null);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/components/QuestCard.tsx
+++ b/frontend/components/QuestCard.tsx
@@ -5,9 +5,10 @@ import { Quest, Difficulty } from '@/types/quest';
 
 interface QuestCardProps {
   quest: Quest;
+  onSelect?: (quest: Quest) => void;
 }
 
-export function QuestCard({ quest }: QuestCardProps) {
+export function QuestCard({ quest, onSelect }: QuestCardProps) {
   const difficultyConfig: Record<
     Difficulty,
     { color: string; label: string; bgColor: string }
@@ -30,74 +31,74 @@ export function QuestCard({ quest }: QuestCardProps) {
   };
 
   const difficulty = difficultyConfig[quest.difficulty];
+  const objectiveList = (() => {
+    if (Array.isArray(quest.objectives)) return quest.objectives;
+    try {
+      const parsed = JSON.parse(quest.objectives);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.error("Failed to parse objectives", error);
+      return [];
+    }
+  })();
 
-  return (
-    <Link href={`/quests/${quest.id}`}>
-      <div className="h-full p-6 bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow cursor-pointer">
-        {/* Header */}
-        <div className="flex items-start justify-between mb-4">
-          <h3 className="text-lg font-bold text-gray-900 flex-1 pr-2">
-            {quest.title}
-          </h3>
-          <span
-            className={`px-3 py-1 text-sm font-semibold rounded-full whitespace-nowrap ${difficulty.bgColor} ${difficulty.color}`}
-          >
-            {difficulty.label}
-          </span>
-        </div>
+  const content = (
+    <div className="h-full p-6 bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow cursor-pointer">
+      <div className="flex items-start justify-between mb-4">
+        <h3 className="text-lg font-bold text-gray-900 flex-1 pr-2">{quest.title}</h3>
+        <span
+          className={`px-3 py-1 text-sm font-semibold rounded-full whitespace-nowrap ${difficulty.bgColor} ${difficulty.color}`}
+        >
+          {difficulty.label}
+        </span>
+      </div>
 
-        {/* Lean Concept Badge */}
-        <div className="mb-4">
-          <span className="inline-block px-2 py-1 text-xs font-medium text-blue-700 bg-blue-100 rounded">
-            {quest.leanConcept}
-          </span>
-        </div>
+      <div className="mb-4">
+        <span className="inline-block px-2 py-1 text-xs font-medium text-blue-700 bg-blue-100 rounded">
+          {quest.leanConcept}
+        </span>
+      </div>
 
-        {/* Description */}
-        <p className="text-sm text-gray-600 mb-4 line-clamp-2">
-          {quest.description}
-        </p>
+      <p className="text-sm text-gray-600 mb-4 line-clamp-2">{quest.description}</p>
 
-        {/* Objectives Preview */}
-        <div className="mb-4">
-          <p className="text-xs font-semibold text-gray-700 mb-2">Objectives:</p>
-          <ul className="text-xs text-gray-600 space-y-1">
-            {(Array.isArray(quest.objectives)
-              ? quest.objectives
-              : JSON.parse(quest.objectives)
-            ).slice(0, 2).map((obj, idx) => (
-              <li key={idx} className="flex items-start">
-                <span className="mr-2">•</span>
-                <span className="line-clamp-1">{obj}</span>
+      <div className="mb-4">
+        <p className="text-xs font-semibold text-gray-700 mb-2">Objectives:</p>
+        <ul className="text-xs text-gray-600 space-y-1">
+          {objectiveList.slice(0, 2).map((obj, idx) => (
+            <li key={idx} className="flex items-start">
+              <span className="mr-2">•</span>
+              <span className="line-clamp-1">{obj}</span>
               </li>
             ))}
-          </ul>
-        </div>
-
-        {/* Footer: XP + Time */}
-        <div className="flex items-center justify-between pt-4 border-t border-gray-200">
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-1">
-              <span className="text-sm font-bold text-amber-600">⭐</span>
-              <span className="text-sm font-semibold text-gray-700">
-                {quest.xpReward} XP
-              </span>
-            </div>
-            <div className="flex items-center gap-1">
-              <span className="text-sm">⏱️</span>
-              <span className="text-sm text-gray-600">
-                {quest.timeEstimate} min
-              </span>
-            </div>
-          </div>
-
-          {quest.skillUnlock && (
-            <div className="text-xs font-medium text-purple-600 bg-purple-50 px-2 py-1 rounded">
-              🔓 Unlock
-            </div>
-          )}
-        </div>
+        </ul>
       </div>
-    </Link>
+
+      <div className="flex items-center justify-between pt-4 border-t border-gray-200">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1">
+            <span className="text-sm font-bold text-amber-600">⭐</span>
+            <span className="text-sm font-semibold text-gray-700">{quest.xpReward} XP</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-sm">⏱️</span>
+            <span className="text-sm text-gray-600">{quest.timeEstimate} min</span>
+          </div>
+        </div>
+
+        {quest.skillUnlock && (
+          <div className="text-xs font-medium text-purple-600 bg-purple-50 px-2 py-1 rounded">🔓 Unlock</div>
+        )}
+      </div>
+    </div>
   );
+
+  if (onSelect) {
+    return (
+      <button type="button" onClick={() => onSelect(quest)} className="text-left w-full">
+        {content}
+      </button>
+    );
+  }
+
+  return <Link href={`/quests/${quest.id}`}>{content}</Link>;
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.1.1",
-    "sonner": "^1.5.0"
+    "sonner": "^1.5.0",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.4.4",

--- a/frontend/src/components/QuestDetailModal.tsx
+++ b/frontend/src/components/QuestDetailModal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import type { Quest } from "@/types/quest";
+import { SubmissionForm } from "@/src/components/SubmissionForm";
+
+interface QuestDetailModalProps {
+  quest: Quest | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const QuestDetailModal: React.FC<QuestDetailModalProps> = ({
+  quest,
+  isOpen,
+  onClose,
+}) => {
+  const [showForm, setShowForm] = useState(false);
+
+  const objectives = useMemo(() => {
+    if (!quest?.objectives) return [];
+    if (Array.isArray(quest.objectives)) return quest.objectives;
+
+    try {
+      const parsed = JSON.parse(quest.objectives);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.error("Unable to parse objectives", error);
+      return [];
+    }
+  }, [quest]);
+
+  if (!isOpen || !quest) return null;
+
+  const handleSubmitSuccess = () => {
+    setShowForm(false);
+    onClose();
+  };
+
+  const handleCancel = () => {
+    setShowForm(false);
+    onClose();
+  };
+
+  const difficultyStars =
+    quest.difficulty === "hard" ? 3 : quest.difficulty === "medium" ? 2 : 1;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 px-4 py-8">
+      <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-start p-6 border-b">
+          <div className="space-y-1">
+            <h2 className="text-2xl font-bold text-gray-900">{quest.title}</h2>
+            <p className="text-sm text-gray-500">{quest.leanConcept}</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleCancel}
+            aria-label="Close quest details"
+            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="p-6 space-y-6">
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-2">Description</h3>
+            <p className="text-gray-700 leading-relaxed">{quest.description}</p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm text-gray-500">Difficulty</p>
+              <p className="font-semibold text-gray-900">{"★".repeat(difficultyStars)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-500">Type</p>
+              <p className="font-semibold text-gray-900">{quest.leanConcept}</p>
+            </div>
+          </div>
+
+          {objectives.length > 0 && (
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-2">Objectives</h3>
+              <ul className="space-y-2">
+                {objectives.map((obj, i) => (
+                  <li key={`${obj}-${i}`} className="flex items-start">
+                    <span className="text-blue-500 mr-2">✓</span>
+                    <span className="text-gray-700">{obj}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="bg-blue-50 p-4 rounded">
+              <p className="text-sm text-gray-600">XP Reward</p>
+              <p className="text-2xl font-bold text-blue-600">+{quest.xpReward}</p>
+            </div>
+            <div className="bg-gray-50 p-4 rounded">
+              <p className="text-sm text-gray-600">Time Estimate</p>
+              <p className="text-2xl font-bold text-gray-800">{quest.timeEstimate} min</p>
+            </div>
+          </div>
+
+          {showForm ? (
+            <SubmissionForm
+              questId={quest.id}
+              onSuccess={handleSubmitSuccess}
+              onCancel={handleCancel}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowForm(true)}
+              className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 transition"
+            >
+              Submit Your Answer
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/SubmissionFeedback.tsx
+++ b/frontend/src/components/SubmissionFeedback.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import React, { useEffect } from "react";
+import type { SubmissionFeedback as FeedbackData } from "@/types/submission";
+
+interface SubmissionFeedbackProps {
+  feedback: FeedbackData;
+  onNext: () => void;
+}
+
+export const SubmissionFeedback: React.FC<SubmissionFeedbackProps> = ({
+  feedback,
+  onNext,
+}) => {
+  useEffect(() => {
+    triggerConfetti();
+  }, []);
+
+  return (
+    <div className="space-y-6 py-8">
+      <div className="text-center">
+        <div className="text-6xl mb-3">✨</div>
+        <h2 className="text-3xl font-bold text-gray-900">Analysis Complete!</h2>
+      </div>
+
+      <div className="text-center">
+        <p className="text-6xl font-bold text-blue-600">{feedback.score}</p>
+        <p className="text-gray-600 text-lg">/100</p>
+      </div>
+
+      <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
+        <div
+          className="bg-gradient-to-r from-blue-500 to-blue-600 h-3 rounded-full transition-all duration-500"
+          style={{ width: `${feedback.score}%` }}
+        />
+      </div>
+
+      <div>
+        <h3 className="font-semibold text-gray-900 mb-2">Feedback</h3>
+        <p className="text-gray-700 leading-relaxed">{feedback.feedback}</p>
+      </div>
+
+      {feedback.improvements && feedback.improvements.length > 0 && (
+        <div>
+          <h3 className="font-semibold text-gray-900 mb-2">Areas to Improve</h3>
+          <ul className="space-y-2">
+            {feedback.improvements.map((imp, i) => (
+              <li key={`${imp}-${i}`} className="flex items-start text-gray-700">
+                <span className="text-orange-500 mr-2">•</span>
+                {imp}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="bg-gradient-to-r from-yellow-100 to-yellow-50 border border-yellow-200 p-6 rounded-lg text-center">
+        <p className="text-4xl mb-2">🎉</p>
+        <p className="text-2xl font-bold text-yellow-700">+{feedback.xpEarned} XP</p>
+      </div>
+
+      {feedback.badgesUnlocked && feedback.badgesUnlocked.length > 0 && (
+        <div>
+          <p className="font-semibold text-gray-900 mb-3">🏅 Badges Unlocked</p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+            {feedback.badgesUnlocked.map((badge) => (
+              <div
+                key={badge.id}
+                className="flex flex-col items-center p-3 bg-yellow-50 rounded-lg"
+              >
+                <div className="text-4xl mb-1">{badge.icon}</div>
+                <p className="text-xs text-center text-gray-700">{badge.name}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <button
+        onClick={onNext}
+        className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 transition"
+      >
+        Next Quest
+      </button>
+    </div>
+  );
+};
+
+function triggerConfetti() {
+  if (typeof window === "undefined") return;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  canvas.style.cssText = "position:fixed;top:0;left:0;pointer-events:none;z-index:9999";
+  document.body.appendChild(canvas);
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const particles: Array<{
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    life: number;
+  }> = [];
+
+  for (let i = 0; i < 50; i += 1) {
+    particles.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height - canvas.height,
+      vx: (Math.random() - 0.5) * 8,
+      vy: Math.random() * 8 + 4,
+      life: 1,
+    });
+  }
+
+  const animate = () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    particles.forEach((particle) => {
+      const p = particle;
+      p.y += p.vy;
+      p.vy += 0.1;
+      p.life -= 0.02;
+
+      ctx.fillStyle = `hsl(${Math.random() * 60 + 30}, 100%, 50%, ${p.life})`;
+      ctx.fillRect(p.x, p.y, 5, 5);
+    });
+
+    if (particles.some((p) => p.life > 0)) {
+      requestAnimationFrame(animate);
+    } else {
+      document.body.removeChild(canvas);
+    }
+  };
+
+  animate();
+}

--- a/frontend/src/components/SubmissionForm.tsx
+++ b/frontend/src/components/SubmissionForm.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useSubmissionStore } from "@/src/store/submissionStore";
+import { SubmissionFeedback } from "./SubmissionFeedback";
+import { SubmissionStatusPoller } from "./SubmissionStatusPoller";
+
+interface SubmissionFormProps {
+  questId: string | number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export const SubmissionForm: React.FC<SubmissionFormProps> = ({
+  questId,
+  onSuccess,
+  onCancel,
+}) => {
+  const {
+    formContent,
+    formFile,
+    submissionStatus,
+    submissionFeedback,
+    submissionError,
+    currentSubmissionId,
+    setFormContent,
+    setFormFile,
+    submitAnswer,
+    resetForm,
+  } = useSubmissionStore();
+
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const isValid = useMemo(
+    () => formContent.length >= 10 && formContent.length <= 2000,
+    [formContent]
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrors([]);
+
+    if (formContent.length < 10) {
+      setErrors(["Answer must be at least 10 characters"]);
+      return;
+    }
+
+    if (formContent.length > 2000) {
+      setErrors(["Answer must not exceed 2000 characters"]);
+      return;
+    }
+
+    if (formFile && formFile.size > 5 * 1024 * 1024) {
+      setErrors(["File size must not exceed 5MB"]);
+      return;
+    }
+
+    try {
+      await submitAnswer(questId, formContent, formFile ?? undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Submit failed";
+      setErrors([message]);
+    }
+  };
+
+  if (submissionStatus === "polling" || submissionStatus === "submitting") {
+    return <SubmissionStatusPoller submissionId={currentSubmissionId ?? 0} />;
+  }
+
+  if (submissionStatus === "completed" && submissionFeedback) {
+    return (
+      <SubmissionFeedback
+        feedback={submissionFeedback}
+        onNext={() => {
+          resetForm();
+          onSuccess();
+        }}
+      />
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {errors.length > 0 && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+          {errors.map((e, i) => (
+            <p key={i}>{e}</p>
+          ))}
+        </div>
+      )}
+
+      {submissionError && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+          {submissionError}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Your Analysis</label>
+        <textarea
+          value={formContent}
+          onChange={(e) => setFormContent(e.target.value)}
+          maxLength={2000}
+          placeholder="Write your detailed analysis here..."
+          className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm"
+          rows={10}
+          disabled={submissionStatus === "submitting"}
+        />
+        <div className="flex justify-between mt-2 text-sm text-gray-600">
+          <span>{formContent.length >= 10 ? "✓" : "✗"} Minimum 10 characters</span>
+          <span>
+            {formContent.length}/2000
+          </span>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Attach Screenshot (optional)</label>
+        <input
+          type="file"
+          accept="image/png,image/jpeg"
+          onChange={(e) => setFormFile(e.target.files?.[0] ?? null)}
+          className="w-full p-3 border border-gray-300 rounded-lg"
+          disabled={submissionStatus === "submitting"}
+        />
+        {formFile && (
+          <p className="mt-2 text-sm text-green-600">
+            ✓ {formFile.name} selected ({(formFile.size / 1024).toFixed(1)} KB)
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-2 pt-4">
+        <button
+          type="submit"
+          disabled={!isValid || submissionStatus === "submitting"}
+          className="flex-1 bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+        >
+          {submissionStatus === "submitting" ? "Submitting..." : "Submit"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            resetForm();
+            onCancel();
+          }}
+          disabled={submissionStatus === "submitting"}
+          className="px-6 py-3 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/frontend/src/components/SubmissionStatusPoller.tsx
+++ b/frontend/src/components/SubmissionStatusPoller.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useSubmissionStore } from "@/src/store/submissionStore";
+
+interface SubmissionStatusPollerProps {
+  submissionId: number;
+}
+
+export const SubmissionStatusPoller: React.FC<SubmissionStatusPollerProps> = ({
+  submissionId,
+}) => {
+  const submissionStatus = useSubmissionStore((state) => state.submissionStatus);
+  const submissionError = useSubmissionStore((state) => state.submissionError);
+  const submissionProgress = useSubmissionStore((state) => state.submissionProgress);
+  const pollSubmissionStatus = useSubmissionStore((state) => state.pollSubmissionStatus);
+  const resetForm = useSubmissionStore((state) => state.resetForm);
+
+  useEffect(() => {
+    if (!submissionId || submissionStatus !== "polling") return;
+
+    let isMounted = true;
+    const pollInterval = setInterval(async () => {
+      if (!isMounted) return;
+      await pollSubmissionStatus(submissionId);
+    }, 2000);
+
+    return () => {
+      isMounted = false;
+      clearInterval(pollInterval);
+    };
+  }, [pollSubmissionStatus, submissionId, submissionStatus]);
+
+  if (submissionStatus === "error") {
+    return (
+      <div className="text-center py-8">
+        <div className="text-6xl mb-4">❌</div>
+        <h3 className="text-xl font-semibold text-gray-900 mb-2">Submission Failed</h3>
+        <p className="text-gray-600 mb-4">{submissionError}</p>
+        <button
+          onClick={() => resetForm()}
+          className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center py-8 space-y-4">
+      <div className="text-4xl mb-4">🔄</div>
+      <h3 className="text-xl font-semibold text-gray-900">Analyzing your submission...</h3>
+      <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+        <div
+          className="bg-blue-600 h-full transition-all duration-300 ease-out"
+          style={{ width: `${submissionProgress}%` }}
+        />
+      </div>
+      <p className="text-gray-600">{Math.round(submissionProgress)}% complete</p>
+      <p className="text-sm text-gray-500">Using Gemini AI to analyze your response...</p>
+    </div>
+  );
+};

--- a/frontend/src/store/submissionStore.ts
+++ b/frontend/src/store/submissionStore.ts
@@ -1,0 +1,134 @@
+"use client";
+
+import { create } from "zustand";
+import type { SubmissionFeedback } from "@/types/submission";
+
+type SubmissionStatus = "idle" | "submitting" | "polling" | "completed" | "error";
+
+interface SubmissionState {
+  currentSubmissionId: number | null;
+  submissionProgress: number;
+  submissionStatus: SubmissionStatus;
+  submissionError: string | null;
+  submissionFeedback: SubmissionFeedback | null;
+  formContent: string;
+  formFile: File | null;
+  setFormContent: (content: string) => void;
+  setFormFile: (file: File | null) => void;
+  setSubmissionProgress: (progress: number) => void;
+  setSubmissionStatus: (status: SubmissionStatus) => void;
+  setSubmissionError: (error: string | null) => void;
+  setSubmissionFeedback: (feedback: SubmissionFeedback | null) => void;
+  setCurrentSubmissionId: (id: number | null) => void;
+  submitAnswer: (questId: number | string, content: string, file?: File) => Promise<number>;
+  pollSubmissionStatus: (submissionId: number) => Promise<SubmissionFeedback | null>;
+  resetForm: () => void;
+}
+
+export const useSubmissionStore = create<SubmissionState>((set) => ({
+  currentSubmissionId: null,
+  submissionProgress: 0,
+  submissionStatus: "idle",
+  submissionError: null,
+  submissionFeedback: null,
+  formContent: "",
+  formFile: null,
+  setFormContent: (content) => set({ formContent: content }),
+  setFormFile: (file) => set({ formFile: file }),
+  setSubmissionProgress: (progress) =>
+    set({ submissionProgress: Math.max(0, Math.min(100, progress)) }),
+  setSubmissionStatus: (status) => set({ submissionStatus: status }),
+  setSubmissionError: (error) => set({ submissionError: error }),
+  setSubmissionFeedback: (feedback) => set({ submissionFeedback: feedback }),
+  setCurrentSubmissionId: (id) => set({ currentSubmissionId: id }),
+  submitAnswer: async (questId, content, file) => {
+    try {
+      set({ submissionStatus: "submitting", submissionError: null, submissionProgress: 0 });
+
+      const formData = new FormData();
+      formData.append("questId", String(questId));
+      formData.append("content", content);
+      if (file) {
+        formData.append("screenshot", file);
+      }
+
+      const response = await fetch("/api/submissions", {
+        method: "POST",
+        body: formData,
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("token") ?? ""}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Submit failed: ${response.statusText}`);
+      }
+
+      const data: { id: number } = await response.json();
+      set({ currentSubmissionId: data.id, submissionStatus: "polling" });
+
+      return data.id;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Submit failed";
+      set({ submissionStatus: "error", submissionError: message });
+      throw error;
+    }
+  },
+  pollSubmissionStatus: async (submissionId) => {
+    try {
+      const response = await fetch(`/api/submissions/${submissionId}/status`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("token") ?? ""}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Poll failed");
+      }
+
+      const data: {
+        progress?: number;
+        status?: string;
+        result?: SubmissionFeedback;
+        error?: string;
+      } = await response.json();
+
+      set({ submissionProgress: data.progress ?? 0 });
+
+      if (data.status === "completed" && data.result) {
+        set({
+          submissionStatus: "completed",
+          submissionFeedback: data.result,
+          submissionProgress: 100,
+        });
+        return data.result;
+      }
+
+      if (data.status === "failed") {
+        set({ submissionStatus: "error", submissionError: data.error ?? "Submission failed" });
+        return null;
+      }
+
+      if (data.status === "pending" || data.status === "processing") {
+        set({ submissionStatus: "polling" });
+      }
+
+      return null;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Poll failed";
+      set({ submissionStatus: "error", submissionError: message });
+      return null;
+    }
+  },
+  resetForm: () =>
+    set({
+      formContent: "",
+      formFile: null,
+      submissionStatus: "idle",
+      submissionError: null,
+      submissionFeedback: null,
+      currentSubmissionId: null,
+      submissionProgress: 0,
+    }),
+}));

--- a/frontend/types/submission.ts
+++ b/frontend/types/submission.ts
@@ -11,3 +11,17 @@ export type Submission = {
   createdAt: Date;
   quest: Quest;
 };
+
+export type SubmissionBadge = {
+  id: string | number;
+  name: string;
+  icon: string;
+};
+
+export type SubmissionFeedback = {
+  score: number;
+  feedback: string;
+  improvements?: string[];
+  xpEarned: number;
+  badgesUnlocked?: SubmissionBadge[];
+};


### PR DESCRIPTION
## Summary
- add Zustand submission store and submission UI components for quest responses
- integrate quest detail modal and submission flow with quest listings
- extend submission types and dependencies to support feedback display

## Testing
- npm run lint *(fails: next lint cannot find `next/tsconfig.json` in current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8ee61b2c83308b2b6e4ea4a3a5ee)