### PR TITLE
Add Ishikawa diagram builder feature

### DIFF
--- a/frontend/data/ishikawaProblems.ts
+++ b/frontend/data/ishikawaProblems.ts
@@ -1,0 +1,44 @@
+import type { IshikawaProblem } from "@/types/ishikawa";
+
+export const ISHIKAWA_PROBLEMS: IshikawaProblem[] = [
+  {
+    id: "defect-rate",
+    title: "High Defect Rate in Assembly Line",
+    description:
+      "The assembly line is producing parts with 15% defect rate, up from 5% last year",
+    category: "manufacturing",
+    difficulty: "medium",
+  },
+  {
+    id: "production-delay",
+    title: "Production Timeline Delays",
+    description:
+      "Manufacturing projects consistently miss deadlines by 10-20 days",
+    category: "manufacturing",
+    difficulty: "hard",
+  },
+  {
+    id: "equipment-breakdown",
+    title: "Frequent Equipment Breakdowns",
+    description:
+      "Key machinery fails 2-3 times per month, causing production stoppages",
+    category: "manufacturing",
+    difficulty: "medium",
+  },
+  {
+    id: "service-wait",
+    title: "Long Customer Wait Times",
+    description:
+      "Service desk customers wait 30+ minutes on average before being served",
+    category: "service",
+    difficulty: "easy",
+  },
+  {
+    id: "quality-inconsistent",
+    title: "Inconsistent Product Quality",
+    description:
+      "Different production batches have significantly different quality levels",
+    category: "manufacturing",
+    difficulty: "hard",
+  },
+];

--- a/frontend/src/components/IshikawaDiagramBuilder.tsx
+++ b/frontend/src/components/IshikawaDiagramBuilder.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import React from "react";
+import type { IshikawaCategoryName, IshikawaProblem } from "@/types/ishikawa";
+import { useIshikawaStore } from "@/src/store/ishikawaStore";
+
+const CATEGORIES_6M: IshikawaCategoryName[] = [
+  "man",
+  "machine",
+  "material",
+  "method",
+  "measurement",
+  "environment",
+];
+
+const CATEGORIES_8P: IshikawaCategoryName[] = [
+  ...CATEGORIES_6M,
+  "people",
+  "place",
+];
+
+const CATEGORY_INFO: Record<
+  IshikawaCategoryName,
+  { jp: string; en: string; icon: string }
+> = {
+  man: { jp: "人", en: "Man", icon: "👤" },
+  machine: { jp: "機械", en: "Machine", icon: "⚙️" },
+  material: { jp: "材料", en: "Material", icon: "📦" },
+  method: { jp: "方法", en: "Method", icon: "📋" },
+  measurement: { jp: "測定", en: "Measurement", icon: "📏" },
+  environment: { jp: "環境", en: "Environment", icon: "🌍" },
+  people: { jp: "人間", en: "People", icon: "👥" },
+  place: { jp: "場所", en: "Place", icon: "📍" },
+};
+
+interface IshikawaDiagramBuilderProps {
+  problem: IshikawaProblem;
+  onGenerateSolutions: () => void;
+  onSubmit: () => void;
+}
+
+export const IshikawaDiagramBuilder: React.FC<
+  IshikawaDiagramBuilderProps
+> = ({ problem, onGenerateSolutions, onSubmit }) => {
+  const {
+    causes,
+    categoryType,
+    setCategoryType,
+    addCause,
+    removeCause,
+    solutions,
+  } = useIshikawaStore();
+  const [newCauseText, setNewCauseText] = React.useState("");
+  const [selectedCategory, setSelectedCategory] =
+    React.useState<IshikawaCategoryName>("man");
+
+  const categories =
+    categoryType === "6M" ? CATEGORIES_6M : CATEGORIES_8P;
+
+  const handleAddCause = () => {
+    if (newCauseText.trim()) {
+      addCause(selectedCategory, newCauseText.trim());
+      setNewCauseText("");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">{problem.title}</h2>
+        <p className="text-gray-600 mt-1">{problem.description}</p>
+      </div>
+
+      <div className="flex gap-2" role="group" aria-label="Category type selection">
+        <button
+          onClick={() => setCategoryType("6M")}
+          className={`px-4 py-2 rounded font-semibold ${
+            categoryType === "6M"
+              ? "bg-blue-600 text-white"
+              : "bg-gray-200 text-gray-700"
+          }`}
+          aria-pressed={categoryType === "6M"}
+          aria-label="Use 6M categories"
+        >
+          6M (Traditional)
+        </button>
+        <button
+          onClick={() => setCategoryType("8P")}
+          className={`px-4 py-2 rounded font-semibold ${
+            categoryType === "8P"
+              ? "bg-blue-600 text-white"
+              : "bg-gray-200 text-gray-700"
+          }`}
+          aria-pressed={categoryType === "8P"}
+          aria-label="Use 8P categories"
+        >
+          8P (Services)
+        </button>
+      </div>
+
+      <div className="bg-gray-50 p-4 rounded space-y-3">
+        <h3 className="font-semibold text-gray-900">Add a Root Cause</h3>
+
+        <div
+          className="grid grid-cols-2 md:grid-cols-3 gap-2"
+          role="group"
+          aria-label="Select category to add a cause"
+        >
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setSelectedCategory(cat)}
+              className={`p-2 rounded text-center text-sm transition ${
+                selectedCategory === cat
+                  ? "bg-blue-600 text-white"
+                  : "bg-white border border-gray-300 hover:border-blue-400"
+              }`}
+              aria-pressed={selectedCategory === cat}
+              aria-label={`Select category ${CATEGORY_INFO[cat].en}`}
+            >
+              <div className="text-lg mb-1" aria-hidden>
+                {CATEGORY_INFO[cat].icon}
+              </div>
+              <div>{CATEGORY_INFO[cat].en}</div>
+            </button>
+          ))}
+        </div>
+
+        <label className="sr-only" htmlFor="ishikawa-cause-input">
+          Describe the cause
+        </label>
+        <input
+          id="ishikawa-cause-input"
+          type="text"
+          value={newCauseText}
+          onChange={(event) => setNewCauseText(event.target.value)}
+          onKeyDown={(event) => event.key === "Enter" && handleAddCause()}
+          placeholder="Describe the cause..."
+          className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          aria-label="Cause description"
+        />
+
+        <button
+          onClick={handleAddCause}
+          className="w-full bg-blue-600 text-white py-2 rounded-lg font-semibold hover:bg-blue-700"
+          aria-label="Add cause to selected category"
+        >
+          Add Cause
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="font-semibold text-gray-900">
+          Added Causes ({causes.length})
+        </h3>
+
+        {categories.map((category) => {
+          const categoryCauses = causes.filter((cause) => cause.category === category);
+          return (
+            <div
+              key={category}
+              className="bg-white p-4 rounded border border-gray-200"
+              aria-label={`${CATEGORY_INFO[category].en} causes list`}
+            >
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-2xl" aria-hidden>
+                  {CATEGORY_INFO[category].icon}
+                </span>
+                <h4 className="font-semibold text-gray-900">
+                  {CATEGORY_INFO[category].en}
+                </h4>
+                <span className="ml-auto text-sm text-gray-600">
+                  {categoryCauses.length} causes
+                </span>
+              </div>
+
+              {categoryCauses.length === 0 ? (
+                <p className="text-sm text-gray-500">
+                  No causes added yet for this category
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {categoryCauses.map((cause) => (
+                    <li
+                      key={cause.id}
+                      className="flex items-center justify-between bg-gray-50 p-2 rounded"
+                    >
+                      <span className="text-sm text-gray-700">
+                        {cause.text}
+                      </span>
+                      <button
+                        onClick={() => removeCause(cause.id)}
+                        className="text-red-600 hover:text-red-700 text-sm font-semibold"
+                        aria-label={`Remove cause ${cause.text}`}
+                      >
+                        ✕
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-col md:flex-row gap-2">
+        <button
+          onClick={onGenerateSolutions}
+          disabled={causes.length < 2}
+          className="flex-1 bg-green-600 text-white py-3 rounded-lg font-semibold hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="Generate solutions based on added causes"
+        >
+          {solutions.length > 0 ? "Regenerate Solutions" : "Generate Solutions"}
+        </button>
+
+        {solutions.length > 0 && (
+          <button
+            onClick={onSubmit}
+            className="flex-1 bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700"
+            aria-label="Submit analysis"
+          >
+            Submit Analysis
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/IshikawaGame.tsx
+++ b/frontend/src/components/IshikawaGame.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useIshikawaStore } from "@/src/store/ishikawaStore";
+import { IshikawaProblemSelector } from "./IshikawaProblemSelector";
+import { IshikawaDiagramBuilder } from "./IshikawaDiagramBuilder";
+import { IshikawaSolutionsDisplay } from "./IshikawaSolutionsDisplay";
+import { IshikawaResults } from "./IshikawaResults";
+
+interface IshikawaGameProps {
+  onComplete: () => void;
+}
+
+export const IshikawaGame: React.FC<IshikawaGameProps> = ({ onComplete }) => {
+  const {
+    currentProblem,
+    solutions,
+    status,
+    selectProblem,
+    generateSolutions,
+    submitAnalysis,
+    reset,
+  } = useIshikawaStore();
+
+  useEffect(() => {
+    return () => reset();
+  }, [reset]);
+
+  if (!currentProblem) {
+    return (
+      <IshikawaProblemSelector
+        onSelectProblem={(problem) => selectProblem(problem)}
+      />
+    );
+  }
+
+  if (status === "completed") {
+    return (
+      <IshikawaResults
+        onNext={() => {
+          reset();
+          onComplete();
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <IshikawaDiagramBuilder
+        problem={currentProblem}
+        onGenerateSolutions={async () => {
+          try {
+            await generateSolutions();
+          } catch (error) {
+            console.error("Failed to generate solutions", error);
+          }
+        }}
+        onSubmit={async () => {
+          try {
+            await submitAnalysis();
+          } catch (error) {
+            console.error("Failed to submit analysis", error);
+          }
+        }}
+      />
+
+      {solutions.length > 0 && (
+        <div className="border-t-2 border-gray-200 pt-8">
+          <IshikawaSolutionsDisplay solutions={solutions} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/IshikawaProblemSelector.tsx
+++ b/frontend/src/components/IshikawaProblemSelector.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React from "react";
+import type { IshikawaProblem } from "@/types/ishikawa";
+import { ISHIKAWA_PROBLEMS } from "@/data/ishikawaProblems";
+
+interface IshikawaProblemSelectorProps {
+  onSelectProblem: (problem: IshikawaProblem) => void;
+}
+
+export const IshikawaProblemSelector: React.FC<
+  IshikawaProblemSelectorProps
+> = ({ onSelectProblem }) => {
+  return (
+    <div className="space-y-6 py-8">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold text-gray-900 mb-2">
+          Ishikawa Diagram Builder
+        </h1>
+        <p className="text-gray-600">
+          Analyze root causes and find solutions
+        </p>
+      </div>
+
+      <div className="space-y-3 max-w-2xl mx-auto">
+        {ISHIKAWA_PROBLEMS.map((problem) => (
+          <button
+            key={problem.id}
+            onClick={() => onSelectProblem(problem)}
+            className="w-full p-4 rounded-lg border-2 border-gray-300 hover:border-blue-400 hover:bg-blue-50 transition text-left"
+            aria-label={`Select problem ${problem.title} difficulty ${problem.difficulty}`}
+          >
+            <div className="flex justify-between items-start">
+              <div>
+                <h3 className="font-semibold text-gray-900">
+                  {problem.title}
+                </h3>
+                <p className="text-sm text-gray-600 mt-1">
+                  {problem.description}
+                </p>
+              </div>
+              <span
+                className={`px-3 py-1 rounded text-sm font-semibold ${
+                  problem.difficulty === "easy"
+                    ? "bg-green-100 text-green-700"
+                    : problem.difficulty === "medium"
+                      ? "bg-yellow-100 text-yellow-700"
+                      : "bg-red-100 text-red-700"
+                }`}
+                aria-label={`${problem.difficulty} difficulty`}
+              >
+                {problem.difficulty.toUpperCase()}
+              </span>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div
+        className="bg-blue-50 p-4 rounded max-w-2xl mx-auto text-center text-sm text-gray-700"
+        role="note"
+      >
+        💡 <span className="font-semibold">Tip:</span> Analyze the problem,
+        identify root causes, and discover solutions!
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/IshikawaResults.tsx
+++ b/frontend/src/components/IshikawaResults.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React from "react";
+import { useIshikawaStore } from "@/src/store/ishikawaStore";
+
+interface IshikawaResultsProps {
+  onNext: () => void;
+}
+
+export const IshikawaResults: React.FC<IshikawaResultsProps> = ({
+  onNext,
+}) => {
+  const result = useIshikawaStore((state) => state.result);
+  const currentProblem = useIshikawaStore((state) => state.currentProblem);
+
+  if (!result || !currentProblem) return null;
+
+  return (
+    <div className="space-y-6 py-8 text-center">
+      <div className="text-6xl mb-3" aria-hidden>
+        ✅
+      </div>
+      <h2 className="text-3xl font-bold text-gray-900">Analysis Complete!</h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-left max-w-3xl mx-auto">
+        <div className="bg-blue-50 p-4 rounded" aria-label="Root causes found">
+          <p className="text-sm text-gray-600">Root Causes Found</p>
+          <p className="text-3xl font-bold text-blue-600">
+            {result.causes.length}
+          </p>
+        </div>
+
+        <div className="bg-purple-50 p-4 rounded" aria-label="Solutions generated">
+          <p className="text-sm text-gray-600">Solutions Generated</p>
+          <p className="text-3xl font-bold text-purple-600">
+            {result.solutions.length}
+          </p>
+        </div>
+
+        <div className="bg-yellow-50 p-4 rounded" aria-label="Score awarded">
+          <p className="text-sm text-gray-600">Score</p>
+          <p className="text-3xl font-bold text-yellow-600">
+            {result.score} pts
+          </p>
+        </div>
+
+        <div className="bg-green-50 p-4 rounded" aria-label="XP earned">
+          <p className="text-sm text-gray-600">XP Earned</p>
+          <p className="text-3xl font-bold text-green-600">
+            +{result.xpEarned} XP
+          </p>
+        </div>
+      </div>
+
+      <button
+        onClick={onNext}
+        className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700"
+        aria-label="Start next analysis"
+      >
+        Next Analysis
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/IshikawaSolutionsDisplay.tsx
+++ b/frontend/src/components/IshikawaSolutionsDisplay.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React from "react";
+import type { IshikawaSolution } from "@/types/ishikawa";
+
+interface IshikawaSolutionsDisplayProps {
+  solutions: IshikawaSolution[];
+}
+
+export const IshikawaSolutionsDisplay: React.FC<
+  IshikawaSolutionsDisplayProps
+> = ({ solutions }) => {
+  const sortedSolutions = [...solutions].sort(
+    (first, second) => second.priority - first.priority
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-2xl font-bold text-gray-900 mb-2">
+          Recommended Solutions
+        </h3>
+        <p className="text-gray-600">
+          Based on your root cause analysis, here are the most effective
+          solutions:
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {sortedSolutions.map((solution, index) => (
+          <div
+            key={solution.id}
+            className="bg-white p-6 rounded-lg border-l-4 border-blue-600"
+            aria-label={`Solution ${index + 1}: ${solution.title}`}
+          >
+            <div className="flex items-start justify-between mb-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="text-2xl font-bold text-blue-600">
+                    #{index + 1}
+                  </span>
+                  <h4 className="text-lg font-bold text-gray-900">
+                    {solution.title}
+                  </h4>
+                </div>
+                <p className="text-sm text-gray-600 mt-1">
+                  {solution.description}
+                </p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4" role="list">
+              <div role="listitem">
+                <p className="text-sm text-gray-600">Impact</p>
+                <p className="text-lg font-bold text-green-600">
+                  {solution.expectedImpact}%
+                </p>
+              </div>
+              <div role="listitem">
+                <p className="text-sm text-gray-600">Difficulty</p>
+                <p className="text-lg font-bold text-gray-900">
+                  {solution.difficulty.toUpperCase()}
+                </p>
+              </div>
+              <div role="listitem">
+                <p className="text-sm text-gray-600">Cost</p>
+                <p className="text-lg font-bold text-gray-900">
+                  {solution.estimatedCost.toUpperCase()}
+                </p>
+              </div>
+              <div role="listitem">
+                <p className="text-sm text-gray-600">Priority</p>
+                <p className="text-lg font-bold text-blue-600">
+                  {solution.priority}/10
+                </p>
+              </div>
+            </div>
+
+            {solution.implementationSteps.length > 0 && (
+              <div>
+                <p className="font-semibold text-gray-900 mb-2">
+                  Implementation Steps:
+                </p>
+                <ol className="space-y-1">
+                  {solution.implementationSteps.map((step, stepIndex) => (
+                    <li key={stepIndex} className="text-sm text-gray-700">
+                      {stepIndex + 1}. {step}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/store/ishikawaStore.ts
+++ b/frontend/src/store/ishikawaStore.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { create } from "zustand";
+import type {
+  IshikawaCause,
+  IshikawaCategoryName,
+  IshikawaResult,
+  IshikawaSolution,
+  IshikawaState,
+} from "@/types/ishikawa";
+
+export const useIshikawaStore = create<IshikawaState>((set, get) => ({
+  currentProblem: null,
+  causes: [],
+  solutions: [],
+  categoryType: "6M",
+  status: "idle",
+  result: null,
+
+  selectProblem: (problem) =>
+    set({
+      currentProblem: problem,
+      causes: [],
+      solutions: [],
+      status: "building",
+      result: null,
+    }),
+
+  setCategoryType: (type) => set({ categoryType: type }),
+
+  addCause: (category, text) => {
+    const newCause: IshikawaCause = {
+      id: `cause-${Date.now()}`,
+      category,
+      text,
+    };
+    set((state) => ({
+      causes: [...state.causes, newCause],
+    }));
+  },
+
+  removeCause: (causeId) => {
+    set((state) => ({
+      causes: state.causes.filter((cause) => cause.id !== causeId),
+    }));
+  },
+
+  generateSolutions: async () => {
+    const { currentProblem, causes } = get();
+    if (!currentProblem) throw new Error("No problem selected");
+
+    try {
+      const response = await fetch("/api/ishikawa/generate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token") ?? ""}`,
+        },
+        body: JSON.stringify({
+          problemId: currentProblem.id,
+          causes,
+        }),
+      });
+
+      if (!response.ok) throw new Error("Generation failed");
+      const solutions: IshikawaSolution[] = await response.json();
+      set({ solutions, status: "analyzing" });
+      return solutions;
+    } catch (error) {
+      console.error("Failed to generate solutions", error);
+      throw error;
+    }
+  },
+
+  submitAnalysis: async () => {
+    const { currentProblem, causes, solutions } = get();
+    if (!currentProblem) throw new Error("No problem selected");
+
+    const score = Math.min(1000, causes.length * 50 + solutions.length * 100);
+
+    const result: IshikawaResult = {
+      problemId: currentProblem.id,
+      causes,
+      solutions,
+      score,
+      xpEarned: Math.round(score / 2),
+      completedAt: new Date(),
+    };
+
+    try {
+      const response = await fetch("/api/ishikawa", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token") ?? ""}`,
+        },
+        body: JSON.stringify(result),
+      });
+
+      if (!response.ok) throw new Error("Submit failed");
+    } catch (error) {
+      console.error("Failed to submit analysis", error);
+    }
+
+    set({ status: "completed", result });
+    return result;
+  },
+
+  reset: () =>
+    set({
+      currentProblem: null,
+      causes: [],
+      solutions: [],
+      categoryType: "6M",
+      status: "idle",
+      result: null,
+    }),
+}));

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@/components/*": ["./components/*"],
+      "@/data/*": ["./data/*"],
       "@/lib/*": ["./lib/*"],
       "@/types/*": ["./types/*"],
       "@/src/*": ["./src/*"]

--- a/frontend/types/ishikawa.ts
+++ b/frontend/types/ishikawa.ts
@@ -1,0 +1,65 @@
+export type IshikawaCategoryType = "6M" | "8P";
+
+export type IshikawaCategoryName =
+  | "man"
+  | "machine"
+  | "material"
+  | "method"
+  | "measurement"
+  | "environment"
+  | "people"
+  | "place";
+
+export interface IshikawaProblem {
+  id: string;
+  title: string;
+  description: string;
+  category: "manufacturing" | "service";
+  difficulty: "easy" | "medium" | "hard";
+}
+
+export interface IshikawaCause {
+  id: string;
+  category: IshikawaCategoryName;
+  text: string;
+  details?: string;
+}
+
+export interface IshikawaSolution {
+  id: string;
+  title: string;
+  description: string;
+  relatedCauses: string[]; // cause IDs
+  implementationSteps: string[];
+  expectedImpact: number; // 0-100
+  difficulty: "easy" | "medium" | "hard";
+  estimatedCost: "low" | "medium" | "high";
+  priority: number; // 1-10
+}
+
+export interface IshikawaResult {
+  problemId: string;
+  causes: IshikawaCause[];
+  solutions: IshikawaSolution[];
+  score: number; // 0-1000
+  xpEarned: number; // 0-500
+  completedAt: Date;
+}
+
+export interface IshikawaState {
+  currentProblem: IshikawaProblem | null;
+  causes: IshikawaCause[];
+  solutions: IshikawaSolution[];
+  categoryType: IshikawaCategoryType;
+  status: "idle" | "building" | "analyzing" | "completed";
+  result: IshikawaResult | null;
+
+  // Methods
+  selectProblem: (problem: IshikawaProblem) => void;
+  setCategoryType: (type: IshikawaCategoryType) => void;
+  addCause: (category: IshikawaCategoryName, text: string) => void;
+  removeCause: (causeId: string) => void;
+  generateSolutions: () => Promise<IshikawaSolution[]>;
+  submitAnalysis: () => Promise<IshikawaResult>;
+  reset: () => void;
+}


### PR DESCRIPTION
## Summary
- add comprehensive Ishikawa types and Zustand store for diagram building
- implement selector, builder, solutions, and results components for the Ishikawa game loop
- seed sample problems and update path aliases for shared data access

## Testing
- npm run lint *(fails: next/tsconfig.json missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a97ba09f88330a0ae19d632f5cf58)