### PR TITLE
Implement Lean RPG frontend routing layout

### DIFF
--- a/frontend/app/(auth)/auth/login/page.tsx
+++ b/frontend/app/(auth)/auth/login/page.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import Link from 'next/link'
+import { FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/src/store/authStore'
+import { LoadingSpinner } from '@/src/components/LoadingSpinner'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const { login, isLoading, error } = useAuthStore()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(email, password)
+      router.push('/dashboard')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md bg-white shadow-lg rounded-xl p-8 mx-4">
+      <h1 className="text-3xl font-bold text-gray-900 mb-6 text-center">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 disabled:opacity-60"
+        >
+          {isLoading ? <LoadingSpinner /> : 'Login'}
+        </button>
+      </form>
+      <p className="mt-6 text-center text-sm text-gray-600">
+        New here?{' '}
+        <Link href="/auth/register" className="font-semibold text-blue-600 hover:underline">
+          Create an account
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/frontend/app/(auth)/auth/logout/page.tsx
+++ b/frontend/app/(auth)/auth/logout/page.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/src/store/authStore'
+import { LoadingSpinner } from '@/src/components/LoadingSpinner'
+
+export default function LogoutPage() {
+  const router = useRouter()
+  const { logout } = useAuthStore()
+
+  useEffect(() => {
+    const doLogout = async () => {
+      await logout()
+      router.replace('/auth/login')
+    }
+    void doLogout()
+  }, [logout, router])
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full max-w-md bg-white shadow-lg rounded-xl p-8 mx-4">
+      <LoadingSpinner />
+      <p className="mt-4 text-gray-700">Logging out...</p>
+    </div>
+  )
+}

--- a/frontend/app/(auth)/auth/register/page.tsx
+++ b/frontend/app/(auth)/auth/register/page.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import Link from 'next/link'
+import { FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/src/store/authStore'
+import { LoadingSpinner } from '@/src/components/LoadingSpinner'
+
+export default function RegisterPage() {
+  const router = useRouter()
+  const { register, isLoading, error } = useAuthStore()
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      await register(username, email, password)
+      router.push('/dashboard')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md bg-white shadow-lg rounded-xl p-8 mx-4">
+      <h1 className="text-3xl font-bold text-gray-900 mb-6 text-center">Register</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Username</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 disabled:opacity-60"
+        >
+          {isLoading ? <LoadingSpinner /> : 'Create account'}
+        </button>
+      </form>
+      <p className="mt-6 text-center text-sm text-gray-600">
+        Already have an account?{' '}
+        <Link href="/auth/login" className="font-semibold text-blue-600 hover:underline">
+          Login
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+
+export default function AuthLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      {children}
+    </div>
+  )
+}

--- a/frontend/app/(game)/audit/page.tsx
+++ b/frontend/app/(game)/audit/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useState } from 'react'
+import type { AuditScene } from '@/types/audit'
+import { AuditGame } from '@/src/components/AuditGame'
+
+export default function AuditPage() {
+  const [scene, setScene] = useState<AuditScene | null>(null)
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">5S Audit</h1>
+        <p className="text-gray-600">Learn and practice 5S methodology</p>
+      </div>
+      <AuditGame scene={scene} onSelectScene={setScene} onComplete={() => setScene(null)} />
+    </div>
+  )
+}

--- a/frontend/app/(game)/dashboard/page.tsx
+++ b/frontend/app/(game)/dashboard/page.tsx
@@ -1,30 +1,59 @@
-"use client";
+'use client'
 
-import { Card } from '@/components/ui/card';
-import { useAuth } from '@/lib/auth-context';
+import { useEffect, useState } from 'react'
+import { usePlayerStore } from '@/src/store/playerStore'
+import { LoadingSpinner } from '@/src/components/LoadingSpinner'
 
 export default function DashboardPage() {
-  const { user } = useAuth();
-  const level = user?.level ?? 1;
-  const xp = user?.xp ?? 0;
+  const player = usePlayerStore((s) => s.player)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    usePlayerStore.getState().fetchPlayer()
+    setLoading(false)
+  }, [])
+
+  if (loading) return <LoadingSpinner />
+  if (!player) return <div>No player data</div>
 
   return (
-    <div className="grid gap-6 md:grid-cols-2">
-      <Card title={`Vítejte, ${user?.name ?? 'hrdinové'}`} description="Základní přehled vašeho hrdiny.">
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="rounded-lg bg-blue-50 p-4">
-            <p className="text-sm text-blue-600">Level</p>
-            <p className="text-3xl font-bold text-primary">{level}</p>
-            <p className="text-xs text-blue-600">Rostete s každým úkolem</p>
-          </div>
-          <div className="rounded-lg bg-indigo-50 p-4">
-            <p className="text-sm text-indigo-600">Zkušenosti</p>
-            <p className="text-3xl font-bold text-indigo-700">{xp}</p>
-            <p className="text-xs text-indigo-600">Sbírejte XP plněním questů</p>
-          </div>
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-4xl font-bold text-gray-900">Dashboard</h1>
+        <p className="text-gray-600">Your Lean RPG progress</p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="bg-blue-50 p-6 rounded-lg border border-blue-200">
+          <p className="text-sm text-gray-600">Level</p>
+          <p className="text-3xl font-bold text-blue-600">{player.level}</p>
         </div>
-      </Card>
-      <Card title="Co je nového?" description="Brzy přidáme questy a lokace. Zatím si užijte nový dashboard." />
+        <div className="bg-green-50 p-6 rounded-lg border border-green-200">
+          <p className="text-sm text-gray-600">Total XP</p>
+          <p className="text-3xl font-bold text-green-600">{player.totalXp}</p>
+        </div>
+        <div className="bg-purple-50 p-6 rounded-lg border border-purple-200">
+          <p className="text-sm text-gray-600">Games Played</p>
+          <p className="text-3xl font-bold text-purple-600">{player.gamesCompleted}</p>
+        </div>
+        <div className="bg-orange-50 p-6 rounded-lg border border-orange-200">
+          <p className="text-sm text-gray-600">Score</p>
+          <p className="text-3xl font-bold text-orange-600">{player.score}</p>
+        </div>
+      </div>
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">Recent Games</h2>
+        <div className="space-y-2">
+          {player.recentResults?.map((result) => (
+            <div key={result.id} className="p-4 bg-gray-50 rounded border border-gray-200">
+              <div className="flex justify-between items-center">
+                <span className="font-semibold capitalize">{result.gameType}</span>
+                <span className="text-green-600 font-bold">+{result.xpEarned} XP</span>
+              </div>
+              <p className="text-sm text-gray-600">{result.completedAt}</p>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
-  );
+  )
 }

--- a/frontend/app/(game)/ishikawa/page.tsx
+++ b/frontend/app/(game)/ishikawa/page.tsx
@@ -1,0 +1,13 @@
+import { IshikawaGame } from '@/src/components/IshikawaGame'
+
+export default function IshikawaPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Ishikawa Diagram</h1>
+        <p className="text-gray-600">Root cause analysis training</p>
+      </div>
+      <IshikawaGame onComplete={() => {}} />
+    </div>
+  )
+}

--- a/frontend/app/(game)/layout.tsx
+++ b/frontend/app/(game)/layout.tsx
@@ -1,27 +1,28 @@
-"use client";
+import { redirect } from 'next/navigation'
+import { Navbar } from '@/src/components/Navbar'
+import { GameSidebar } from '@/src/components/GameSidebar'
+import { StatsBar } from '@/src/components/StatsBar'
+import { getSession } from '@/src/utils/auth'
+import type { ReactNode } from 'react'
 
-import { Sidebar } from '@/components/layout/sidebar';
-import { AuthGuard } from '@/components/layout/auth-guard';
+export default async function GameLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const session = await getSession()
+  if (!session) {
+    redirect('/auth/login')
+  }
 
-export default function GameLayout({ children }: { children: React.ReactNode }) {
   return (
-    <AuthGuard>
-      <div className="flex min-h-screen bg-gray-50">
-        <div className="w-64 shrink-0">
-          <Sidebar />
-        </div>
-        <main className="flex-1 p-6">
-          <div className="mx-auto max-w-6xl space-y-6">
-            <header className="flex items-center justify-between rounded-lg bg-white p-4 shadow-sm">
-              <div>
-                <p className="text-sm text-gray-500">Lean RPG</p>
-                <h1 className="text-xl font-semibold text-gray-900">Herní panel</h1>
-              </div>
-            </header>
-            {children}
-          </div>
-        </main>
+    <div className="h-screen flex flex-col">
+      <Navbar />
+      <StatsBar />
+      <div className="flex flex-1 overflow-hidden">
+        <GameSidebar />
+        <main className="flex-1 overflow-auto bg-white p-6">{children}</main>
       </div>
-    </AuthGuard>
-  );
+    </div>
+  )
 }

--- a/frontend/app/(game)/leaderboard/page.tsx
+++ b/frontend/app/(game)/leaderboard/page.tsx
@@ -1,0 +1,8 @@
+export default function LeaderboardPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold text-gray-900">Leaderboard</h1>
+      <p className="text-gray-600">Global leaderboard coming soon.</p>
+    </div>
+  )
+}

--- a/frontend/app/(game)/page.tsx
+++ b/frontend/app/(game)/page.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link'
+
+export default function GameHub() {
+  const games = [
+    {
+      id: 'audit',
+      title: '5S Audit',
+      description: 'Learn 5S methodology through audit scenarios',
+      icon: '📋',
+      href: '/audit',
+      difficulties: ['Easy', 'Medium', 'Hard'],
+    },
+    {
+      id: 'ishikawa',
+      title: 'Ishikawa Diagram',
+      description: 'Root cause analysis with fishbone diagrams',
+      icon: '🎣',
+      href: '/ishikawa',
+      difficulties: ['Easy', 'Medium', 'Hard'],
+    },
+  ]
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-4xl font-bold text-gray-900 mb-2">Game Hub</h1>
+        <p className="text-gray-600">Choose a mini-game to improve your Lean skills</p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {games.map((game) => (
+          <Link key={game.id} href={game.href}>
+            <div className="p-6 border-2 border-gray-300 rounded-lg hover:border-blue-500 hover:shadow-lg transition cursor-pointer">
+              <div className="text-4xl mb-3">{game.icon}</div>
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">{game.title}</h2>
+              <p className="text-gray-600 mb-4">{game.description}</p>
+              <div className="flex gap-2">
+                {game.difficulties.map((d) => (
+                  <span
+                    key={d}
+                    className="px-3 py-1 bg-blue-100 text-blue-700 rounded text-sm font-semibold"
+                  >
+                    {d}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/(game)/skills/page.tsx
+++ b/frontend/app/(game)/skills/page.tsx
@@ -1,17 +1,8 @@
-import { ProgressionDashboard } from "@/components/skills/ProgressionDashboard";
-import { SkillTreeViewer } from "@/components/skills/SkillTreeViewer";
-
 export default function SkillsPage() {
   return (
-    <div className="space-y-6">
-      <div className="rounded-lg bg-white p-4 shadow-sm">
-        <h2 className="text-xl font-semibold text-gray-900">Skill Tree Hub</h2>
-        <p className="text-sm text-gray-600">
-          Track your Lean mastery, unlock new techniques, and manage your active bonuses.
-        </p>
-      </div>
-      <ProgressionDashboard />
-      <SkillTreeViewer />
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold text-gray-900">Skills</h1>
+      <p className="text-gray-600">Skill tree coming soon.</p>
     </div>
-  );
+  )
 }

--- a/frontend/app/api/audit/route.ts
+++ b/frontend/app/api/audit/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyToken } from '@/src/utils/auth'
+
+export async function POST(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get('authorization')
+    const userId = verifyToken(authHeader)
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const result = await req.json()
+    console.log('Audit result:', result)
+
+    return NextResponse.json({ success: true, id: 'audit-result' })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/frontend/app/api/auth/login/route.ts
+++ b/frontend/app/api/auth/login/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const { email } = await req.json()
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: '1',
+      username: email.split('@')[0],
+      email,
+      exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    })
+  ).toString('base64')
+  const mockToken = `header.${payload}.signature`
+  const response = NextResponse.json({
+    token: mockToken,
+    user: { id: '1', username: email.split('@')[0], email },
+  })
+  response.cookies.set('token', mockToken, { path: '/', httpOnly: false })
+  return response
+}

--- a/frontend/app/api/auth/logout/route.ts
+++ b/frontend/app/api/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const response = NextResponse.json({ success: true })
+  response.cookies.set('token', '', { path: '/', expires: new Date(0) })
+  return response
+}

--- a/frontend/app/api/auth/register/route.ts
+++ b/frontend/app/api/auth/register/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const { username, email } = await req.json()
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: '2',
+      username,
+      email,
+      exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    })
+  ).toString('base64')
+  const mockToken = `header.${payload}.signature`
+  const response = NextResponse.json({
+    token: mockToken,
+    user: { id: '2', username, email },
+  })
+  response.cookies.set('token', mockToken, { path: '/', httpOnly: false })
+  return response
+}

--- a/frontend/app/api/ishikawa/generate/route.ts
+++ b/frontend/app/api/ishikawa/generate/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyToken } from '@/src/utils/auth'
+
+export async function POST(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get('authorization')
+    const userId = verifyToken(authHeader)
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const { problemId, causes } = await req.json()
+
+    const mockSolutions = [
+      {
+        id: 'sol-1',
+        title: 'Implement Root Cause A Action',
+        description: 'Take action on identified root cause',
+        relatedCauses: causes?.map((c: { id: string }) => c.id) ?? [],
+        expectedImpact: 25,
+        difficulty: 'easy',
+        estimatedCost: 'low',
+        priority: 9,
+        implementationSteps: ['Step 1: Do something', 'Step 2: Do something else'],
+      },
+    ]
+
+    return NextResponse.json(mockSolutions)
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/frontend/app/api/ishikawa/route.ts
+++ b/frontend/app/api/ishikawa/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyToken } from '@/src/utils/auth'
+
+export async function POST(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get('authorization')
+    const userId = verifyToken(authHeader)
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const body = await req.json()
+    console.log('Ishikawa result:', body)
+
+    return NextResponse.json({ success: true, id: 'mock-id' })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/frontend/app/api/player/route.ts
+++ b/frontend/app/api/player/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { verifyToken } from '@/src/utils/auth'
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization')
+  const userId = verifyToken(authHeader)
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const player = {
+    id: userId,
+    username: 'player1',
+    email: 'player1@example.com',
+    level: 5,
+    totalXp: 4200,
+    currentXp: 400,
+    score: 8200,
+    gamesCompleted: 12,
+    createdAt: new Date().toISOString(),
+    recentResults: [
+      { id: 'r1', gameType: 'audit', score: 85, xpEarned: 150, completedAt: new Date().toISOString() },
+      { id: 'r2', gameType: 'ishikawa', score: 92, xpEarned: 200, completedAt: new Date().toISOString() },
+    ],
+  }
+
+  return NextResponse.json(player)
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,21 +1,23 @@
-import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
-import './globals.css';
-import { Providers } from './providers';
-
-const inter = Inter({ subsets: ['latin'] });
+import type { Metadata } from 'next'
+import './globals.css'
+import { Providers } from '@/src/components/Providers'
+import type { ReactNode } from 'react'
 
 export const metadata: Metadata = {
   title: 'Lean RPG',
-  description: 'Frontend for Lean RPG'
-};
+  description: 'Gamified Lean training',
+}
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
   return (
-    <html lang="en">
-      <body className={inter.className}>
+    <html lang="cs">
+      <body className="bg-gray-50 text-gray-900">
         <Providers>{children}</Providers>
       </body>
     </html>
-  );
+  )
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,29 +1,27 @@
-"use client";
+import Link from 'next/link'
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/lib/auth-context';
-import { Loader2 } from 'lucide-react';
-
-export default function HomePage() {
-  const { user, loading, ready } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!ready) return;
-    if (user) {
-      router.replace('/dashboard');
-    } else {
-      router.replace('/login');
-    }
-  }, [user, ready, router]);
-
+export default function Home() {
   return (
-    <main className="flex min-h-screen items-center justify-center text-sm text-gray-700">
-      <div className="flex items-center gap-2">
-        <Loader2 className="h-5 w-5 animate-spin text-primary" />
-        <span>Načítání aplikace...</span>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-blue-600 to-blue-800">
+      <div className="text-center px-4">
+        <h1 className="text-5xl font-bold text-white mb-4">Lean RPG</h1>
+        <p className="text-xl text-blue-100 mb-8">
+          Learn Lean methodologies through gamified mini-games
+        </p>
+
+        <div className="space-y-3">
+          <Link href="/auth/login">
+            <button className="w-full max-w-md bg-white text-blue-600 font-bold py-3 px-6 rounded-lg hover:bg-blue-50">
+              Login
+            </button>
+          </Link>
+          <Link href="/auth/register">
+            <button className="w-full max-w-md bg-blue-500 text-white font-bold py-3 px-6 rounded-lg hover:bg-blue-400">
+              Register
+            </button>
+          </Link>
+        </div>
       </div>
-    </main>
-  );
+    </div>
+  )
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+const PUBLIC_PATHS = ['/auth/login', '/auth/register', '/auth/logout', '/']
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const isPublic = PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith('/api/auth'))
+
+  if (isPublic) {
+    return NextResponse.next()
+  }
+
+  const token = request.cookies.get('token')?.value
+  if (!token && pathname.startsWith('/api')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (!token && !isPublic && pathname.startsWith('/')) {
+    const url = new URL('/auth/login', request.url)
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+}

--- a/frontend/next/tsconfig.json
+++ b/frontend/next/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  }
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,25 @@
+import { getClientToken, clearToken } from '@/src/utils/auth'
+
+export async function apiFetch<T = unknown>(
+  url: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const token = getClientToken()
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {}),
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  const response = await fetch(url, { ...options, headers })
+  if (!response.ok) {
+    if (response.status === 401) {
+      clearToken()
+    }
+    const errorMessage = await response.text()
+    throw new Error(errorMessage || 'Request failed')
+  }
+  return response.json() as Promise<T>
+}

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,0 +1,9 @@
+export const API_ENDPOINTS = {
+  login: '/api/auth/login',
+  register: '/api/auth/register',
+  logout: '/api/auth/logout',
+  player: '/api/player',
+  audit: '/api/audit',
+  ishikawa: '/api/ishikawa',
+  ishikawaGenerate: '/api/ishikawa/generate',
+}

--- a/frontend/src/components/GameSidebar.tsx
+++ b/frontend/src/components/GameSidebar.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export function GameSidebar() {
+  const pathname = usePathname()
+
+  const links = [
+    { href: '/dashboard', label: '📊 Dashboard', icon: '📊' },
+    { href: '/audit', label: '📋 5S Audit', icon: '📋' },
+    { href: '/ishikawa', label: '🎣 Ishikawa', icon: '🎣' },
+    { href: '/skills', label: '⭐ Skills', icon: '⭐' },
+    { href: '/leaderboard', label: '🏆 Leaderboard', icon: '🏆' },
+  ]
+
+  return (
+    <aside className="w-64 bg-gray-100 border-r border-gray-300 overflow-y-auto">
+      <div className="p-6 space-y-2">
+        {links.map((link) => (
+          <Link key={link.href} href={link.href}>
+            <div
+              className={`p-3 rounded cursor-pointer transition ${
+                pathname === link.href
+                  ? 'bg-blue-600 text-white font-semibold'
+                  : 'text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              {link.icon} {link.label}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center gap-2 text-blue-600">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
+      <span className="text-sm font-semibold">Loading...</span>
+    </div>
+  )
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useAuthStore } from '@/src/store/authStore'
+
+export function Navbar() {
+  const router = useRouter()
+  const { user, logout } = useAuthStore()
+
+  const handleLogout = async () => {
+    await logout()
+    router.push('/auth/login')
+  }
+
+  return (
+    <nav className="bg-blue-600 text-white px-6 py-4 shadow-lg">
+      <div className="flex items-center justify-between max-w-7xl mx-auto">
+        <Link href="/">
+          <h1 className="text-2xl font-bold cursor-pointer">🚀 Lean RPG</h1>
+        </Link>
+        <div className="flex items-center gap-4">
+          <span className="text-sm">
+            Welcome, <strong>{user?.username ?? 'Player'}</strong>
+          </span>
+          <button
+            onClick={handleLogout}
+            className="px-4 py-2 bg-red-500 rounded hover:bg-red-600"
+          >
+            Logout
+          </button>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode, useState } from 'react'
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient())
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}

--- a/frontend/src/components/StatsBar.tsx
+++ b/frontend/src/components/StatsBar.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePlayerStore } from '@/src/store/playerStore'
+
+export function StatsBar() {
+  const player = usePlayerStore((s) => s.player)
+
+  useEffect(() => {
+    usePlayerStore.getState().fetchPlayer()
+  }, [])
+
+  if (!player) return null
+
+  const xpToNextLevel = 1000
+  const xpProgress = Math.min((player.currentXp / xpToNextLevel) * 100, 100)
+
+  return (
+    <div className="bg-white border-b border-gray-200 px-6 py-3">
+      <div className="flex items-center justify-between max-w-7xl mx-auto">
+        <div className="flex items-center gap-8">
+          <div className="text-center">
+            <p className="text-xs text-gray-600">LEVEL</p>
+            <p className="text-2xl font-bold text-blue-600">{player.level}</p>
+          </div>
+          <div className="w-64">
+            <div className="flex justify-between items-center mb-1">
+              <span className="text-xs font-semibold text-gray-700">XP</span>
+              <span className="text-xs text-gray-600">
+                {player.currentXp} / {xpToNextLevel}
+              </span>
+            </div>
+            <div className="w-full bg-gray-300 rounded-full h-2 overflow-hidden">
+              <div
+                className="bg-green-500 h-full transition-all"
+                style={{ width: `${xpProgress}%` }}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-gray-600">TOTAL SCORE</p>
+          <p className="text-2xl font-bold text-orange-600">{player.score}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand'
+import type { AuthState, AuthUser } from '@/src/types/auth'
+import { saveToken, clearToken } from '@/src/utils/auth'
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  token: null,
+  isLoading: false,
+  error: null,
+  login: async (email: string, password: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+      if (!res.ok) throw new Error('Login failed')
+      const data = await res.json()
+      saveToken(data.token)
+      set({ user: data.user as AuthUser, token: data.token, isLoading: false })
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false })
+      throw error
+    }
+  },
+  register: async (username: string, email: string, password: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password }),
+      })
+      if (!res.ok) throw new Error('Registration failed')
+      const data = await res.json()
+      saveToken(data.token)
+      set({ user: data.user as AuthUser, token: data.token, isLoading: false })
+    } catch (error: any) {
+      set({ error: error.message, isLoading: false })
+      throw error
+    }
+  },
+  logout: async () => {
+    await fetch('/api/auth/logout', { method: 'POST' })
+    clearToken()
+    set({ user: null, token: null })
+  },
+}))

--- a/frontend/src/store/playerStore.ts
+++ b/frontend/src/store/playerStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+import type { Player } from '@/src/types/player'
+
+interface PlayerStoreState {
+  player: Player | null
+  fetchPlayer: () => Promise<void>
+  updateXp: (xpGained: number) => void
+}
+
+export const usePlayerStore = create<PlayerStoreState>((set, get) => ({
+  player: null,
+  fetchPlayer: async () => {
+    try {
+      const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null
+      const res = await fetch('/api/player', {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      })
+      if (!res.ok) throw new Error('Failed to fetch player')
+      const player = await res.json()
+      set({ player })
+    } catch (error) {
+      console.error('Fetch player error:', error)
+    }
+  },
+  updateXp: (xpGained: number) => {
+    set((state) => {
+      if (!state.player) return state
+      return {
+        player: {
+          ...state.player,
+          totalXp: state.player.totalXp + xpGained,
+          currentXp: state.player.currentXp + xpGained,
+          score: state.player.score + Math.round(xpGained / 2),
+        },
+      }
+    })
+  },
+}))

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,15 @@
+export interface AuthUser {
+  id: string
+  username: string
+  email: string
+}
+
+export interface AuthState {
+  user: AuthUser | null
+  token: string | null
+  isLoading: boolean
+  error: string | null
+  login: (email: string, password: string) => Promise<void>
+  register: (username: string, email: string, password: string) => Promise<void>
+  logout: () => Promise<void>
+}

--- a/frontend/src/types/player.ts
+++ b/frontend/src/types/player.ts
@@ -1,0 +1,20 @@
+export interface GameResult {
+  id: string
+  gameType: 'audit' | 'ishikawa'
+  score: number
+  xpEarned: number
+  completedAt: string
+}
+
+export interface Player {
+  id: string
+  username: string
+  email: string
+  level: number
+  totalXp: number
+  currentXp: number
+  score: number
+  gamesCompleted: number
+  createdAt: string
+  recentResults?: GameResult[]
+}

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,0 +1,79 @@
+import { cookies } from 'next/headers'
+
+const TOKEN_KEY = 'token'
+
+type DecodedPayload = {
+  sub?: string
+  userId?: string
+  id?: string
+  username?: string
+  email?: string
+  exp?: number
+}
+
+export function decodeToken(token: string): DecodedPayload | null {
+  try {
+    const [, payload] = token.split('.')
+    if (!payload) return null
+    const decoded =
+      typeof window === 'undefined'
+        ? Buffer.from(payload, 'base64').toString()
+        : atob(payload)
+    return JSON.parse(decoded)
+  } catch (error) {
+    console.error('Failed to decode token', error)
+    return null
+  }
+}
+
+function extractBearer(rawToken: string | string[] | null): string | null {
+  if (!rawToken) return null
+  const tokenValue = Array.isArray(rawToken) ? rawToken[1] ?? rawToken[0] : rawToken
+  if (!tokenValue) return null
+  if (tokenValue.includes(' ')) {
+    const [, value] = tokenValue.split(' ')
+    return value ?? null
+  }
+  return tokenValue
+}
+
+export function verifyToken(rawToken: string | string[] | null): string | null {
+  const token = extractBearer(rawToken)
+  if (!token) return null
+  const payload = decodeToken(token)
+  if (!payload) return null
+  if (payload.exp && Date.now() / 1000 > payload.exp) return null
+  return payload.sub ?? payload.userId ?? payload.id ?? null
+}
+
+export async function getSession() {
+  const token = cookies().get(TOKEN_KEY)?.value
+  if (!token) return null
+  const payload = decodeToken(token)
+  if (!payload) return null
+  return {
+    userId: payload.sub ?? payload.userId ?? payload.id ?? null,
+    username: payload.username,
+    email: payload.email,
+    token,
+  }
+}
+
+export function saveToken(token: string) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(TOKEN_KEY, token)
+    document.cookie = `${TOKEN_KEY}=${token}; path=/;`
+  }
+}
+
+export function clearToken() {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(TOKEN_KEY)
+    document.cookie = `${TOKEN_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+  }
+}
+
+export function getClientToken() {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(TOKEN_KEY)
+}

--- a/frontend/src/utils/colors.ts
+++ b/frontend/src/utils/colors.ts
@@ -1,0 +1,5 @@
+export const brandColors = {
+  primary: '#2563eb',
+  secondary: '#0ea5e9',
+  accent: '#f97316',
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,15 +1,32 @@
 {
-  "extends": "next/tsconfig.json",
+  "extends": "./next/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["./components/*"],
-      "@/data/*": ["./data/*"],
-      "@/lib/*": ["./lib/*"],
-      "@/types/*": ["./types/*"],
-      "@/src/*": ["./src/*"]
+      "@/components/*": [
+        "./components/*"
+      ],
+      "@/data/*": [
+        "./data/*"
+      ],
+      "@/lib/*": [
+        "./lib/*"
+      ],
+      "@/types/*": [
+        "./types/*"
+      ],
+      "@/src/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- implement new root, auth, and game layouts/pages with navbar, sidebar, stats bar, and landing/game hub experiences
- add zustand auth/player stores, shared providers/utilities, and Tailwind-driven components for navigation and loading states
- scaffold API routes, middleware, and endpoint helpers for auth, player stats, audit, and Ishikawa game flows

## Testing
- npm run lint *(fails: missing @typescript-eslint/no-unused-vars rule in eslint configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9c845e948330aebbd074125bcbe9)