### PR TITLE
Add tenant-aware tenant APIs with caching

### DIFF
--- a/backend/__tests__/integration/isolation.test.ts
+++ b/backend/__tests__/integration/isolation.test.ts
@@ -1,0 +1,108 @@
+import http from "http";
+import type { AddressInfo } from "net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const redisStore = new Map<string, string>();
+const redisClient = {
+  status: "ready",
+  get: vi.fn(async (key: string) => redisStore.get(key) ?? null),
+  set: vi.fn(async (key: string, value: string) => {
+    redisStore.set(key, value);
+    return "OK";
+  }),
+  del: vi.fn(async (key: string) => {
+    redisStore.delete(key);
+    return 1;
+  }),
+  flushall: vi.fn(async () => {
+    redisStore.clear();
+    return "OK";
+  }),
+  ping: vi.fn(async () => "PONG"),
+};
+
+vi.mock("../../src/lib/redis.js", () => ({
+  getRedis: vi.fn(() => redisClient as any),
+  closeRedis: vi.fn(async () => undefined),
+  redisGet: async (key: string) => redisClient.get(key),
+  redisSet: async (key: string, value: string) => redisClient.set(key, value),
+  redisDel: async (key: string) => redisClient.del(key),
+  redisFlushAll: async () => redisClient.flushall(),
+}));
+
+const tenants = new Map<string, any>();
+const factories = new Map<string, any[]>();
+
+function seedTenant(slug: string, id: string) {
+  tenants.set(slug, { id, slug, name: slug, createdAt: new Date(), language: "en", timezone: "UTC" });
+  factories.set(id, [{ id: `${id}-f1`, tenantId: id, name: `${slug} factory`, zones: [], workshops: [] }]);
+}
+
+const factoryFindMany = vi.fn(async ({ where }: any) => factories.get(where.tenantId) ?? []);
+const prismaMock = {
+  tenant: {
+    findUnique: vi.fn(async ({ where }: any) => {
+      if (where.slug) return tenants.get(where.slug) ?? null;
+      if (where.id) return Array.from(tenants.values()).find((t) => t.id === where.id) ?? null;
+      return null;
+    }),
+  },
+  factoryConfiguration: { findMany: factoryFindMany },
+  auditTemplate: { findMany: vi.fn(async () => []) },
+  lPATemplate: { findMany: vi.fn(async () => []) },
+  $transaction: vi.fn(async (fn: any) => fn(prismaMock)),
+};
+
+vi.mock("../../src/lib/prisma.js", () => ({ default: prismaMock }));
+
+vi.mock("../../src/middleware/rateLimiter.js", () => ({
+  globalRateLimiter: (_req: any, _res: any, next: any) => next(),
+  submissionRateLimiter: (_req: any, _res: any, next: any) => next(),
+  authRateLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  verifyToken: (_req: any, _res: any, next: any) => next(),
+  adminCheck: (_req: any, _res: any, next: any) => next(),
+}));
+
+let server: http.Server;
+let baseUrl: string;
+
+async function startServer() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "file:./test.db";
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? "secret";
+  const app = (await import("../../src/app.js")).default;
+  server = app.listen(0);
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+}
+
+describe("data isolation", () => {
+  beforeAll(async () => {
+    seedTenant("tenant-a", "tenant-a-id");
+    seedTenant("tenant-b", "tenant-b-id");
+    await startServer();
+  });
+
+  afterAll(async () => {
+    server?.close();
+  });
+
+  beforeEach(() => {
+    redisStore.clear();
+    vi.clearAllMocks();
+  });
+
+  it("scopes factory queries by tenantId", async () => {
+    const response = await fetch(`${baseUrl}/api/tenants/tenant-a/config`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(factoryFindMany).toHaveBeenCalledWith({
+      where: { tenantId: "tenant-a-id" },
+      include: { zones: true, workshops: true },
+    });
+    expect(payload.data.factories[0].tenantId).toBe("tenant-a-id");
+  });
+});

--- a/backend/__tests__/middleware/tenantContext.test.ts
+++ b/backend/__tests__/middleware/tenantContext.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, vi, beforeEach, it } from "vitest";
+import type { Request, Response } from "express";
+
+const prismaMock = vi.hoisted(() => ({
+  tenant: { findUnique: vi.fn() },
+  $transaction: vi.fn(async (handler: any) =>
+    handler({ tenant: { findUnique: prismaMock.tenant.findUnique } })
+  ),
+}));
+
+vi.mock("../../src/lib/prisma.js", () => ({
+  default: prismaMock,
+}));
+
+import { tenantContext } from "../../src/middleware/tenantContext.js";
+
+const mockTenant = { id: "tenant-1", slug: "demo-tenant", name: "Demo" } as any;
+
+describe("tenantContext middleware", () => {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json } as unknown as Response));
+
+  const next = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.tenant.findUnique.mockImplementation(async ({ where: { slug } }: any) =>
+      slug === mockTenant.slug ? mockTenant : null
+    );
+    prismaMock.$transaction.mockImplementation(async (handler: any) =>
+      handler({ tenant: { findUnique: prismaMock.tenant.findUnique } })
+    );
+  });
+
+  it("resolves slug from params and attaches tenant", async () => {
+    const req = { params: { slug: "demo-tenant" } } as unknown as Request;
+    const res = { status } as unknown as Response;
+
+    await tenantContext(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.tenantId).toBe(mockTenant.id);
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves slug from header when params missing", async () => {
+    const req = {
+      params: {},
+      header: (name: string) => (name === "x-tenant-slug" ? "demo-tenant" : undefined),
+    } as unknown as Request;
+    const res = { status } as unknown as Response;
+
+    await tenantContext(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.tenantId).toBe(mockTenant.id);
+  });
+
+  it("rejects invalid slug format", async () => {
+    const req = { params: { slug: "INVALID" } } as unknown as Request;
+    const res = { status } as unknown as Response;
+
+    await tenantContext(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "INVALID_SLUG", success: false })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when tenant missing", async () => {
+    const req = { params: { slug: "missing" } } as unknown as Request;
+    const res = { status } as unknown as Response;
+
+    await tenantContext(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "TENANT_NOT_FOUND", success: false })
+    );
+  });
+});

--- a/backend/__tests__/routes/tenants.test.ts
+++ b/backend/__tests__/routes/tenants.test.ts
@@ -1,0 +1,223 @@
+import http from "http";
+import type { AddressInfo } from "net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const redisStore = new Map<string, string>();
+const redisClient = {
+  status: "ready",
+  get: vi.fn(async (key: string) => redisStore.get(key) ?? null),
+  set: vi.fn(async (key: string, value: string) => {
+    redisStore.set(key, value);
+    return "OK";
+  }),
+  del: vi.fn(async (key: string) => {
+    redisStore.delete(key);
+    return 1;
+  }),
+  flushall: vi.fn(async () => {
+    redisStore.clear();
+    return "OK";
+  }),
+  ping: vi.fn(async () => "PONG"),
+};
+
+vi.mock("../../src/lib/redis.js", () => ({
+  getRedis: vi.fn(() => redisClient as any),
+  closeRedis: vi.fn(async () => undefined),
+  redisGet: async (key: string) => redisClient.get(key),
+  redisSet: async (key: string, value: string) => redisClient.set(key, value),
+  redisDel: async (key: string) => redisClient.del(key),
+  redisFlushAll: async () => redisClient.flushall(),
+}));
+
+const tenants = new Map<string, any>();
+const factories = new Map<string, any[]>();
+const audits = new Map<string, any[]>();
+const lpas = new Map<string, any[]>();
+
+function seedTenant(slug: string, id: string) {
+  const now = new Date();
+  const tenant = {
+    id,
+    slug,
+    name: slug,
+    language: "en",
+    timezone: "Europe/Prague",
+    primaryColor: "#111111",
+    createdAt: now,
+  };
+  tenants.set(slug, tenant);
+  factories.set(id, []);
+  audits.set(id, []);
+  lpas.set(id, []);
+  return tenant;
+}
+
+const prismaMock = {
+  tenant: {
+    findUnique: vi.fn(async ({ where }: any) => {
+      if (where.slug) return tenants.get(where.slug) ?? null;
+      if (where.id) return Array.from(tenants.values()).find((t) => t.id === where.id) ?? null;
+      return null;
+    }),
+    create: vi.fn(async ({ data }: any) => {
+      const tenant = { ...data, id: `t-${tenants.size + 1}`, createdAt: new Date() };
+      tenants.set(tenant.slug, tenant);
+      factories.set(tenant.id, []);
+      audits.set(tenant.id, []);
+      lpas.set(tenant.id, []);
+      return tenant;
+    }),
+    update: vi.fn(async ({ where, data }: any) => {
+      const existing = tenants.get(where.slug);
+      if (!existing) throw new Error("not found");
+      const updated = { ...existing, ...data };
+      tenants.set(where.slug, updated);
+      return updated;
+    }),
+    findMany: vi.fn(async ({ skip = 0, take = 20 }: any) =>
+      Array.from(tenants.values())
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        .slice(skip, skip + take)
+        .map((tenant) => ({
+          ...tenant,
+          _count: {
+            factories: factories.get(tenant.id)?.length ?? 0,
+            auditTemplates: audits.get(tenant.id)?.length ?? 0,
+            lpaTemplates: lpas.get(tenant.id)?.length ?? 0,
+          },
+        }))
+    ),
+    count: vi.fn(async () => tenants.size),
+  },
+  factoryConfiguration: {
+    findMany: vi.fn(async ({ where }: any) => factories.get(where.tenantId) ?? []),
+  },
+  auditTemplate: {
+    findMany: vi.fn(async ({ where }: any) => audits.get(where.tenantId) ?? []),
+  },
+  lPATemplate: {
+    findMany: vi.fn(async ({ where }: any) => lpas.get(where.tenantId) ?? []),
+  },
+  $transaction: vi.fn(async (fn: any) => fn(prismaMock)),
+};
+
+vi.mock("../../src/lib/prisma.js", () => ({ default: prismaMock }));
+
+vi.mock("../../src/middleware/rateLimiter.js", () => ({
+  globalRateLimiter: (_req: any, _res: any, next: any) => next(),
+  submissionRateLimiter: (_req: any, _res: any, next: any) => next(),
+  authRateLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  verifyToken: (req: any, _res: any, next: any) => {
+    req.user = { userId: 1, role: "admin" };
+    next();
+  },
+  adminCheck: (_req: any, _res: any, next: any) => next(),
+}));
+
+let server: http.Server;
+let baseUrl: string;
+
+async function startServer() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "file:./test.db";
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? "secret";
+  const app = (await import("../../src/app.js")).default;
+  server = app.listen(0);
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+}
+
+describe("tenant routes", () => {
+  beforeAll(async () => {
+    seedTenant("magna-nymburk", "tenant-1");
+    seedTenant("acme", "tenant-2");
+    factories.set("tenant-1", [
+      { id: "f1", tenantId: "tenant-1", name: "Factory 1", zones: [], workshops: [] },
+    ]);
+    audits.set("tenant-1", [{ id: "a1", tenantId: "tenant-1", title: "Audit" }]);
+    lpas.set("tenant-1", [{ id: "l1", tenantId: "tenant-1", title: "LPA" }]);
+    await startServer();
+  });
+
+  afterAll(async () => {
+    server?.close();
+  });
+
+  beforeEach(() => {
+    redisStore.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns config and caches when missing", async () => {
+    const response = await fetch(`${baseUrl}/api/tenants/magna-nymburk/config`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-cache")).toBe("MISS");
+    expect(payload.success).toBe(true);
+    expect(payload.data.factories).toHaveLength(1);
+    expect(redisStore.has("tenant:config:magna-nymburk")).toBe(true);
+  });
+
+  it("returns cached config on subsequent requests", async () => {
+    redisStore.set(
+      "tenant:config:magna-nymburk",
+      JSON.stringify({ cached: true, factories: [] })
+    );
+
+    const response = await fetch(`${baseUrl}/api/tenants/magna-nymburk/config`);
+    const payload = await response.json();
+
+    expect(response.headers.get("x-cache")).toBe("HIT");
+    expect(payload.data.cached).toBe(true);
+    expect(prismaMock.factoryConfiguration.findMany).not.toHaveBeenCalled();
+  });
+
+  it("allows admin to refresh cache", async () => {
+    redisStore.set("tenant:config:magna-nymburk", "stale");
+
+    const response = await fetch(`${baseUrl}/api/tenants/magna-nymburk/config/refresh`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(redisStore.has("tenant:config:magna-nymburk")).toBe(false);
+  });
+
+  it("creates tenant with defaults", async () => {
+    const response = await fetch(`${baseUrl}/api/admin/tenants`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug: "new-tenant", name: "New Tenant" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(payload.data.tenant.slug).toBe("new-tenant");
+    expect(payload.data.tenant.language).toBe("en");
+  });
+
+  it("prevents slug mutation on update", async () => {
+    const response = await fetch(`${baseUrl}/api/admin/tenants/magna-nymburk`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug: "changed" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.code).toBe("INVALID_SLUG");
+  });
+
+  it("lists tenants with pagination info", async () => {
+    const response = await fetch(`${baseUrl}/api/admin/tenants?page=1&limit=2`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.data.tenants.length).toBeGreaterThan(0);
+    expect(payload.data.pagination.total).toBe(tenants.size);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,83 @@
+import express from "express";
+import cors from "cors";
+import { config } from "./config.js";
+import { requestLogger } from "./middleware/logger.js";
+import { errorHandler } from "./middleware/errorHandler.js";
+import { verifyToken, adminCheck } from "./middleware/auth.js";
+import { globalRateLimiter, submissionRateLimiter } from "./middleware/rateLimiter.js";
+
+// Routes
+import authRoutes from "./routes/auth.js";
+import questRoutes from "./routes/quests.js";
+import submissionRoutes from "./routes/submissions.js";
+import userRoutes from "./routes/users.js";
+import areaRoutes from "./routes/areas.js";
+import healthRouter from "./routes/health.js";
+import jobsRouter from "./routes/jobs.js";
+import gembaRouter from "./routes/gemba.js";
+import fiveSRouter from "./routes/fiveS.js";
+import problemSolvingRouter from "./routes/problemSolving.js";
+import skillRouter from "./routes/skills.js";
+import progressionRouter from "./routes/progression.js";
+import gamificationRouter from "./routes/gamification.js";
+import tenantRoutes from "./routes/tenants.js";
+import adminTenantRoutes from "./routes/admin/tenants.js";
+
+export function createApp() {
+  const app = express();
+
+  if (config.logging.enableHttpLogs) {
+    app.use(requestLogger);
+  }
+
+  app.set("trust proxy", 1);
+
+  app.use(cors({ origin: config.cors.origin }));
+  app.use(express.json());
+  app.use(globalRateLimiter);
+
+  // Public routes
+  app.use("/auth", authRoutes);
+  app.use("/api/auth", authRoutes);
+  app.use(healthRouter);
+
+  // Tenant-aware routes
+  app.use("/api/tenants", tenantRoutes);
+
+  // Admin routes
+  app.use("/api/admin/tenants", verifyToken, adminCheck, adminTenantRoutes);
+
+  // Protected routes
+  app.use("/quests", verifyToken, questRoutes);
+  app.use("/submissions", verifyToken, submissionRateLimiter, submissionRoutes);
+  app.use("/users", verifyToken, userRoutes);
+  app.use("/areas", verifyToken, areaRoutes);
+  app.use("/api/quests", verifyToken, questRoutes);
+  app.use("/api/submissions", verifyToken, submissionRateLimiter, submissionRoutes);
+  app.use("/api/users", verifyToken, userRoutes);
+  app.use("/api/areas", verifyToken, areaRoutes);
+  app.use("/api/jobs", verifyToken, jobsRouter);
+  app.use("/api/gemba", verifyToken, gembaRouter);
+  app.use("/api/5s", verifyToken, fiveSRouter);
+  app.use("/api/problem-solving", verifyToken, problemSolvingRouter);
+  app.use("/api/skills", verifyToken, skillRouter);
+  app.use("/api/progression", verifyToken, progressionRouter);
+  app.use("/api/gamification", verifyToken, gamificationRouter);
+
+  app.use((req, res) => {
+    res.status(404).json({
+      success: false,
+      error: "Not found",
+      code: "NOT_FOUND",
+      statusCode: 404,
+      path: req.path,
+    });
+  });
+
+  app.use(errorHandler);
+
+  return app;
+}
+
+export const app = createApp();
+export default app;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,75 +1,12 @@
-import express from "express";
-import cors from "cors";
 import { config } from "./config.js";
 import logger from "./lib/logger.js";
 import { getRedis, closeRedis } from "./lib/redis.js";
 import { startSubmissionWorker } from "./queue/submissionWorker.js";
 import { getSubmissionQueue, closeQueue } from "./queue/queueFactory.js";
-import { requestLogger } from "./middleware/logger.js";
-import { errorHandler } from "./middleware/errorHandler.js";
-import { verifyToken } from "./middleware/auth.js";
-import { globalRateLimiter, submissionRateLimiter } from "./middleware/rateLimiter.js";
+import app from "./app.js";
 
-// Routes
-import authRoutes from "./routes/auth.js";
-import questRoutes from "./routes/quests.js";
-import submissionRoutes from "./routes/submissions.js";
-import userRoutes from "./routes/users.js";
-import areaRoutes from "./routes/areas.js";
-import healthRouter from "./routes/health.js";
-import jobsRouter from "./routes/jobs.js";
-import gembaRouter from "./routes/gemba.js";
-import fiveSRouter from "./routes/fiveS.js";
-import problemSolvingRouter from "./routes/problemSolving.js";
-import skillRouter from "./routes/skills.js";
-import progressionRouter from "./routes/progression.js";
-import gamificationRouter from "./routes/gamification.js";
-
-const app = express();
 const PORT = config.app.port;
 const HOST = config.app.host;
-
-if (config.logging.enableHttpLogs) {
-  app.use(requestLogger);
-}
-
-app.set("trust proxy", 1);
-
-app.use(cors({ origin: config.cors.origin }));
-app.use(express.json());
-app.use(globalRateLimiter);
-
-// Public routes
-app.use("/auth", authRoutes);
-app.use("/api/auth", authRoutes);
-app.use(healthRouter);
-
-// Protected routes
-app.use("/quests", verifyToken, questRoutes);
-app.use("/submissions", verifyToken, submissionRateLimiter, submissionRoutes);
-app.use("/users", verifyToken, userRoutes);
-app.use("/areas", verifyToken, areaRoutes);
-app.use("/api/quests", verifyToken, questRoutes);
-app.use("/api/submissions", verifyToken, submissionRateLimiter, submissionRoutes);
-app.use("/api/users", verifyToken, userRoutes);
-app.use("/api/areas", verifyToken, areaRoutes);
-app.use("/api/jobs", verifyToken, jobsRouter);
-app.use("/api/gemba", verifyToken, gembaRouter);
-app.use("/api/5s", verifyToken, fiveSRouter);
-app.use("/api/problem-solving", verifyToken, problemSolvingRouter);
-app.use("/api/skills", verifyToken, skillRouter);
-app.use("/api/progression", verifyToken, progressionRouter);
-app.use("/api/gamification", verifyToken, gamificationRouter);
-
-app.use((req, res) => {
-  res.status(404).json({
-    error: "Not found",
-    code: "NOT_FOUND",
-    path: req.path,
-  });
-});
-
-app.use(errorHandler);
 
 async function startServer() {
   try {

--- a/backend/src/lib/redis.ts
+++ b/backend/src/lib/redis.ts
@@ -2,11 +2,35 @@ import Redis from "ioredis";
 import { config } from "../config.js";
 import logger from "./logger.js";
 
-/**
- * Redis client instance
- * Used for: Bull queue, caching, session store, etc.
- */
 let redis: Redis | null = null;
+
+function attachEventHandlers(client: Redis) {
+  client.on("connect", () => {
+    logger.info({
+      message: "Redis connected",
+      url: config.redis.url,
+    });
+  });
+
+  client.on("ready", () => {
+    logger.info({ message: "Redis ready" });
+  });
+
+  client.on("end", () => {
+    logger.warn({ message: "Redis connection closed" });
+  });
+
+  client.on("error", (error) => {
+    logger.error({
+      message: "Redis connection error",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  client.on("reconnecting", (time) => {
+    logger.warn({ message: "Redis reconnecting", delay: time });
+  });
+}
 
 export function getRedis(): Redis {
   if (redis) {
@@ -16,27 +40,11 @@ export function getRedis(): Redis {
   redis = new Redis(config.redis.url, {
     enableReadyCheck: false,
     enableOfflineQueue: false,
-    maxRetriesPerRequest: null, // Required for Bull
-    retryStrategy: (times: number) => {
-      const delay = Math.min(times * 50, 2000);
-      return delay;
-    },
+    maxRetriesPerRequest: null,
+    retryStrategy: (times: number) => Math.min(times * 50, 2000),
   });
 
-  redis.on("connect", () => {
-    logger.info({
-      message: "Redis connected",
-      url: config.redis.url,
-    });
-  });
-
-  redis.on("error", (error) => {
-    logger.error({
-      message: "Redis connection error",
-      error: error instanceof Error ? error.message : String(error),
-    });
-  });
-
+  attachEventHandlers(redis);
   return redis;
 }
 
@@ -47,4 +55,63 @@ export async function closeRedis(): Promise<void> {
   }
 }
 
-export default getRedis();
+export async function redisGet(key: string): Promise<string | null> {
+  try {
+    const client = getRedis();
+    return await client.get(key);
+  } catch (error) {
+    logger.error({
+      message: "redis_get_failed",
+      key,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+export async function redisSet(
+  key: string,
+  value: string,
+  expiryMode?: "EX" | "PX",
+  time?: number
+): Promise<void> {
+  try {
+    const client = getRedis();
+    if (expiryMode && typeof time === "number") {
+      await client.set(key, value, expiryMode, time);
+    } else {
+      await client.set(key, value);
+    }
+  } catch (error) {
+    logger.error({
+      message: "redis_set_failed",
+      key,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function redisDel(key: string): Promise<void> {
+  try {
+    const client = getRedis();
+    await client.del(key);
+  } catch (error) {
+    logger.error({
+      message: "redis_del_failed",
+      key,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function redisFlushAll(): Promise<void> {
+  try {
+    const client = getRedis();
+    await client.flushall();
+  } catch (error) {
+    logger.error({
+      message: "redis_flush_failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -40,3 +40,15 @@ export function verifyToken(req: Request, res: Response, next: NextFunction) {
     return next(new HttpError("Invalid token", 401));
   }
 }
+
+export function adminCheck(req: Request, res: Response, next: NextFunction) {
+  if (!req.user) {
+    return next(new HttpError("Missing token", 401, "UNAUTHORIZED"));
+  }
+
+  if (req.user.role !== "admin") {
+    return next(new HttpError("Admin access required", 403, "FORBIDDEN"));
+  }
+
+  return next();
+}

--- a/backend/src/middleware/dataIsolation.ts
+++ b/backend/src/middleware/dataIsolation.ts
@@ -1,0 +1,28 @@
+/**
+ * Data isolation enforcement helpers.
+ *
+ * Always scope Prisma queries by tenantId to avoid cross-tenant data leaks.
+ * Example:
+ *   await prisma.user.findMany({ where: { tenantId: req.tenantId } });
+ */
+import { NextFunction, Request, Response } from "express";
+import type { ApiErrorResponse } from "../types/response.js";
+
+export function requireTenantContext(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  if (!req.tenantId) {
+    const body: ApiErrorResponse = {
+      success: false,
+      error: "Tenant context is required",
+      code: "TENANT_SLUG_REQUIRED",
+      statusCode: 400,
+      hint: "Run tenantContext middleware before protected routes",
+    };
+    return res.status(body.statusCode).json(body);
+  }
+
+  return next();
+}

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -22,8 +22,10 @@ export function errorHandler(err: Error, req: Request, res: Response, next: Next
     });
 
     return res.status(err.statusCode).json({
+      success: false,
       error: err.message,
       code: err.code,
+      statusCode: err.statusCode,
       ...(err.details && { details: err.details }),
       timestamp: new Date().toISOString(),
       requestId,
@@ -40,8 +42,10 @@ export function errorHandler(err: Error, req: Request, res: Response, next: Next
   });
 
   res.status(500).json({
+    success: false,
     error: "Internal server error",
     code: "INTERNAL_ERROR",
+    statusCode: 500,
     timestamp: new Date().toISOString(),
     requestId,
   });

--- a/backend/src/middleware/tenantContext.ts
+++ b/backend/src/middleware/tenantContext.ts
@@ -1,0 +1,90 @@
+import { NextFunction, Request, Response } from "express";
+import prisma from "../lib/prisma.js";
+import logger from "../lib/logger.js";
+import type { ApiErrorResponse } from "../types/response.js";
+
+const SLUG_REGEX = /^[a-z0-9-]+$/;
+
+type SlugSource = "params" | "header" | "query";
+
+function extractSlug(req: Request): { slug: string | null; source: SlugSource | null } {
+  if (typeof req.params?.slug === "string") {
+    return { slug: req.params.slug, source: "params" };
+  }
+
+  const headerSlug = req.header("x-tenant-slug");
+  if (headerSlug) {
+    return { slug: headerSlug, source: "header" };
+  }
+
+  const querySlug = typeof req.query.tenant === "string" ? req.query.tenant : null;
+  if (querySlug) {
+    return { slug: querySlug, source: "query" };
+  }
+
+  return { slug: null, source: null };
+}
+
+function respondError(res: Response, body: ApiErrorResponse) {
+  return res.status(body.statusCode).json(body);
+}
+
+export async function tenantContext(req: Request, res: Response, next: NextFunction) {
+  const { slug, source } = extractSlug(req);
+
+  if (!slug) {
+    return respondError(res, {
+      success: false,
+      error: "Tenant slug is required",
+      code: "TENANT_SLUG_REQUIRED",
+      statusCode: 400,
+      hint: "Provide slug via URL, X-Tenant-Slug header, or ?tenant query param",
+    });
+  }
+
+  if (!SLUG_REGEX.test(slug)) {
+    return respondError(res, {
+      success: false,
+      error: "Invalid tenant slug",
+      code: "INVALID_SLUG",
+      statusCode: 400,
+      hint: "Use lowercase letters, numbers, and dashes only",
+    });
+  }
+
+  try {
+    logger.debug({ message: "tenant_slug_extracted", slug, source });
+
+    const tenant = await prisma.$transaction((tx) =>
+      tx.tenant.findUnique({ where: { slug } })
+    );
+
+    if (!tenant) {
+      return respondError(res, {
+        success: false,
+        error: "Tenant not found",
+        code: "TENANT_NOT_FOUND",
+        statusCode: 404,
+      });
+    }
+
+    req.tenantId = tenant.id;
+    req.tenantSlug = tenant.slug;
+    req.tenant = tenant;
+
+    return next();
+  } catch (error) {
+    logger.error({
+      message: "tenant_resolution_failed",
+      slug,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    return respondError(res, {
+      success: false,
+      error: "Unable to resolve tenant",
+      code: "INTERNAL_ERROR",
+      statusCode: 500,
+    });
+  }
+}

--- a/backend/src/queue/queueFactory.ts
+++ b/backend/src/queue/queueFactory.ts
@@ -1,5 +1,5 @@
 import Queue, { Job, JobOptions } from "bull";
-import redis from "../lib/redis.js";
+import { getRedis } from "../lib/redis.js";
 import { JOB_TYPES, SubmissionAnalysisJob, JobResult } from "../types/jobs.js";
 import logger from "../lib/logger.js";
 import { config } from "../config.js";
@@ -21,7 +21,7 @@ export function getSubmissionQueue(): SubmissionQueue {
   submissionQueue = new Queue<SubmissionAnalysisJob, JobResult>(
     JOB_TYPES.SUBMISSION_ANALYSIS,
     {
-      redis,
+      redis: getRedis(),
       settings: {
         maxStalledCount: 2, // Max times job can be reprocessed
         lockRenewTime: 30_000, // Renew lock every 30s

--- a/backend/src/routes/admin/tenants.ts
+++ b/backend/src/routes/admin/tenants.ts
@@ -1,0 +1,189 @@
+import { Router } from "express";
+import { z } from "zod";
+import prisma from "../../lib/prisma.js";
+import { redisDel } from "../../lib/redis.js";
+import { asyncHandler } from "../../middleware/errorHandler.js";
+import type { ApiSuccessResponse, ApiErrorResponse } from "../../types/response.js";
+
+const router = Router();
+
+const tenantCreateSchema = z.object({
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  language: z.string().optional(),
+  timezone: z.string().optional(),
+  primaryColor: z.string().optional(),
+  description: z.string().optional(),
+  locale: z.string().optional(),
+  defaultTheme: z.enum(["light", "dark"]).optional(),
+  leanMethodologies: z.array(z.string()).optional(),
+  secondaryColor: z.string().optional(),
+  logoUrl: z.string().optional(),
+});
+
+const tenantUpdateSchema = tenantCreateSchema.partial().omit({ slug: true });
+
+function validationError(details: unknown): ApiErrorResponse {
+  return {
+    success: false,
+    error: "Validation error",
+    code: "VALIDATION_ERROR",
+    statusCode: 400,
+    details: details as Record<string, unknown>,
+  };
+}
+
+router.post(
+  "/",
+  asyncHandler(async (req, res) => {
+    const parsed = tenantCreateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json(validationError(parsed.error.format()));
+    }
+
+    const payload = parsed.data;
+    const existing = await prisma.tenant.findUnique({ where: { slug: payload.slug } });
+    if (existing) {
+      const body: ApiErrorResponse = {
+        success: false,
+        error: "Slug already exists",
+        code: "SLUG_EXISTS",
+        statusCode: 400,
+      };
+      return res.status(400).json(body);
+    }
+
+    const tenant = await prisma.tenant.create({
+      data: {
+        slug: payload.slug,
+        name: payload.name,
+        language: payload.language ?? "en",
+        timezone: payload.timezone ?? "Europe/Prague",
+        primaryColor: payload.primaryColor,
+        description: payload.description,
+        locale: payload.locale ?? "en-US",
+        defaultTheme: payload.defaultTheme ?? "light",
+        leanMethodologies: payload.leanMethodologies ?? ["5S", "LPA", "Ishikawa"],
+        secondaryColor: payload.secondaryColor,
+        logoUrl: payload.logoUrl,
+      },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        language: true,
+        timezone: true,
+        primaryColor: true,
+      },
+    });
+
+    const response: ApiSuccessResponse<{ tenant: typeof tenant }> = {
+      success: true,
+      data: { tenant },
+    };
+
+    return res.status(201).json(response);
+  })
+);
+
+router.put(
+  "/:slug",
+  asyncHandler(async (req, res) => {
+    if (req.body?.slug) {
+      const body: ApiErrorResponse = {
+        success: false,
+        error: "Slug cannot be changed",
+        code: "INVALID_SLUG",
+        statusCode: 400,
+      };
+      return res.status(400).json(body);
+    }
+
+    const parsed = tenantUpdateSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json(validationError(parsed.error.format()));
+    }
+
+    const slug = req.params.slug;
+    const existing = await prisma.tenant.findUnique({ where: { slug } });
+    if (!existing) {
+      const body: ApiErrorResponse = {
+        success: false,
+        error: "Tenant not found",
+        code: "TENANT_NOT_FOUND",
+        statusCode: 404,
+      };
+      return res.status(404).json(body);
+    }
+
+    const updated = await prisma.tenant.update({
+      where: { slug },
+      data: parsed.data,
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        language: true,
+        timezone: true,
+        primaryColor: true,
+      },
+    });
+
+    await redisDel(`tenant:config:${slug}`);
+
+    const response: ApiSuccessResponse<{ tenant: typeof updated }> = {
+      success: true,
+      data: { tenant: updated },
+    };
+
+    return res.json(response);
+  })
+);
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const page = Math.max(1, Number(req.query.page) || 1);
+    const limitRaw = Number(req.query.limit) || 20;
+    const limit = Math.min(Math.max(1, limitRaw), 100);
+    const skip = (page - 1) * limit;
+
+    const [tenants, total] = await Promise.all([
+      prisma.tenant.findMany({
+        skip,
+        take: limit,
+        orderBy: { createdAt: "desc" },
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          language: true,
+          timezone: true,
+          createdAt: true,
+          _count: { select: { factories: true, auditTemplates: true, lpaTemplates: true } },
+        },
+      }),
+      prisma.tenant.count(),
+    ]);
+
+    const response: ApiSuccessResponse<{
+      tenants: typeof tenants;
+      pagination: { page: number; limit: number; total: number; pages: number };
+    }> = {
+      success: true,
+      data: {
+        tenants,
+        pagination: {
+          page,
+          limit,
+          total,
+          pages: Math.max(1, Math.ceil(total / limit)),
+        },
+      },
+    };
+
+    return res.json(response);
+  })
+);
+
+export default router;

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import os from "os";
 import { performance } from "perf_hooks";
 import prisma from "../lib/prisma.js";
-import redis from "../lib/redis.js";
+import { getRedis } from "../lib/redis.js";
 import logger from "../lib/logger.js";
 import { geminiService } from "../services/GeminiService.js";
 import { getQueueStats } from "../queue/queueFactory.js";
@@ -42,11 +42,12 @@ function getMemoryUsage(): MemoryUsageMb {
 
 router.get("/health", async (req: Request, res: Response) => {
   const requestId = (req as Request & { requestId?: string }).requestId;
+  const redisClient = getRedis();
 
   try {
     const [database, redisStatus] = await Promise.all([
       measureLatency(() => prisma.$queryRaw`SELECT 1` as any),
-      measureLatency(() => redis.ping() as any),
+      measureLatency(() => redisClient.ping() as any),
     ]);
 
     let queue: QueueHealth = {

--- a/backend/src/routes/tenants.ts
+++ b/backend/src/routes/tenants.ts
@@ -1,0 +1,100 @@
+import { Router } from "express";
+import prisma from "../lib/prisma.js";
+import logger from "../lib/logger.js";
+import { tenantContext } from "../middleware/tenantContext.js";
+import { requireTenantContext } from "../middleware/dataIsolation.js";
+import { redisGet, redisSet, redisDel } from "../lib/redis.js";
+import { asyncHandler } from "../middleware/errorHandler.js";
+import { verifyToken, adminCheck } from "../middleware/auth.js";
+import type { ApiSuccessResponse } from "../types/response.js";
+
+const router = Router();
+
+const CACHE_TTL_SECONDS = 300;
+
+router.get(
+  "/:slug/config",
+  tenantContext,
+  requireTenantContext,
+  asyncHandler(async (req, res) => {
+    const slug = req.tenantSlug ?? req.params.slug;
+    const cacheKey = `tenant:config:${slug}`;
+
+    const cached = await redisGet(cacheKey);
+    if (cached) {
+      res.setHeader("Cache-Control", `public, max-age=${CACHE_TTL_SECONDS}`);
+      res.setHeader("X-Cache", "HIT");
+      const payload = JSON.parse(cached);
+      const response: ApiSuccessResponse<typeof payload> = { success: true, data: payload };
+      return res.json(response);
+    }
+
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(500).json({
+        success: false,
+        error: "Tenant context missing",
+        code: "INTERNAL_ERROR",
+        statusCode: 500,
+      });
+    }
+
+    const [factories, auditTemplates, lpaTemplates, tenant] = await Promise.all([
+      prisma.factoryConfiguration.findMany({
+        where: { tenantId },
+        include: { zones: true, workshops: true },
+      }),
+      prisma.auditTemplate.findMany({ where: { tenantId } }),
+      prisma.lPATemplate.findMany({ where: { tenantId } }),
+      prisma.tenant.findUnique({ where: { id: tenantId } }),
+    ]);
+
+    if (!tenant) {
+      return res.status(404).json({
+        success: false,
+        error: "Tenant not found",
+        code: "TENANT_NOT_FOUND",
+        statusCode: 404,
+      });
+    }
+
+    const payload = {
+      tenant,
+      factories,
+      auditTemplates,
+      lpaTemplates,
+    };
+
+    await redisSet(cacheKey, JSON.stringify(payload), "EX", CACHE_TTL_SECONDS);
+
+    logger.info({ message: "tenant_config_cached", tenantId, cacheKey });
+
+    res.setHeader("Cache-Control", `public, max-age=${CACHE_TTL_SECONDS}`);
+    res.setHeader("X-Cache", "MISS");
+    const response: ApiSuccessResponse<typeof payload> = { success: true, data: payload };
+    return res.json(response);
+  })
+);
+
+router.get(
+  "/:slug/config/refresh",
+  verifyToken,
+  adminCheck,
+  tenantContext,
+  requireTenantContext,
+  asyncHandler(async (req, res) => {
+    const slug = req.tenantSlug ?? req.params.slug;
+    const cacheKey = `tenant:config:${slug}`;
+
+    await redisDel(cacheKey);
+
+    const response: ApiSuccessResponse<{ cacheKey: string }> = {
+      success: true,
+      data: { cacheKey },
+    };
+
+    return res.json(response);
+  })
+);
+
+export default router;

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -5,5 +5,8 @@ declare module "express-serve-static-core" {
     validatedBody?: unknown;
     validatedParams?: unknown;
     validatedQuery?: unknown;
+    tenantId?: string;
+    tenantSlug?: string;
+    tenant?: import("@prisma/client").Tenant;
   }
 }

--- a/backend/src/types/response.ts
+++ b/backend/src/types/response.ts
@@ -1,0 +1,15 @@
+export interface ApiSuccessResponse<T> {
+  success: true;
+  data: T;
+}
+
+export interface ApiErrorResponse {
+  success: false;
+  error: string;
+  code: string;
+  statusCode: number;
+  hint?: string;
+  details?: Record<string, unknown>;
+}
+
+export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;


### PR DESCRIPTION
## Summary
- add tenant-aware middleware, shared response types, and data-isolation helper to enforce scoped tenant access
- implement tenant configuration caching endpoint plus admin tenant create/update/list APIs and restructure server bootstrap around a reusable app
- enhance Redis utility and add comprehensive tests for tenant middleware, routes, and isolation behavior

## Testing
- DATABASE_URL="file:./test.db" JWT_SECRET="secret" npx vitest run __tests__/routes/tenants.test.ts __tests__/integration/isolation.test.ts __tests__/middleware/tenantContext.test.ts
- DATABASE_URL="file:./test.db" JWT_SECRET="secret" npm test *(fails in pre-existing schema/seed/badge/leaderboard suites; Prisma client not generated and some service assertions still failing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bcaec834883308a91d97e94cd770f)