### PR TITLE
Add tenant context and dynamic tenant dashboard

### DIFF
--- a/frontend/app/(game)/audit/page.tsx
+++ b/frontend/app/(game)/audit/page.tsx
@@ -1,19 +1,20 @@
 'use client'
 
-import { useState } from 'react'
-import type { AuditScene } from '@/types/audit'
 import { AuditGame } from '@/src/components/AuditGame'
+import { TenantProvider } from '@/src/contexts/TenantProvider'
+
+const DEFAULT_TENANT = process.env.NEXT_PUBLIC_DEFAULT_TENANT_SLUG ?? null
 
 export default function AuditPage() {
-  const [scene, setScene] = useState<AuditScene | null>(null)
-
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-gray-900">5S Audit</h1>
-        <p className="text-gray-600">Learn and practice 5S methodology</p>
+    <TenantProvider initialSlug={DEFAULT_TENANT ?? undefined}>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">5S Audit</h1>
+          <p className="text-gray-600">Learn and practice 5S methodology</p>
+        </div>
+        <AuditGame />
       </div>
-      <AuditGame scene={scene} onSelectScene={setScene} onComplete={() => setScene(null)} />
-    </div>
+    </TenantProvider>
   )
 }

--- a/frontend/app/(game)/gemba/5s/mini-game/page.tsx
+++ b/frontend/app/(game)/gemba/5s/mini-game/page.tsx
@@ -1,19 +1,20 @@
-'use client';
+'use client'
 
-import { useState } from 'react';
-import type { AuditScene } from '@/types/audit';
-import { AuditGame } from '@/src/components/AuditGame';
+import { AuditGame } from '@/src/components/AuditGame'
+import { TenantProvider } from '@/src/contexts/TenantProvider'
 
-export default function FiveSAuditMiniGamePage() {
-  const [selectedScene, setSelectedScene] = useState<AuditScene | null>(null);
+const DEFAULT_TENANT = process.env.NEXT_PUBLIC_DEFAULT_TENANT_SLUG ?? null
 
+export default function GembaMiniGamePage() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <AuditGame
-        scene={selectedScene}
-        onSelectScene={(scene) => setSelectedScene(scene)}
-        onComplete={() => setSelectedScene(null)}
-      />
-    </div>
-  );
+    <TenantProvider initialSlug={DEFAULT_TENANT ?? undefined}>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Gemba 5S Mini-game</h1>
+          <p className="text-gray-600">Identify and categorize issues on the shop floor.</p>
+        </div>
+        <AuditGame />
+      </div>
+    </TenantProvider>
+  )
 }

--- a/frontend/app/tenant/[slug]/dashboard/page.tsx
+++ b/frontend/app/tenant/[slug]/dashboard/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { AuditGame } from "@/src/components/AuditGame";
+import { FactoryMap } from "@/src/components/FactoryMap";
+import { LPAGame } from "@/src/components/LPAGame";
+import { TenantError } from "@/src/components/TenantError";
+import { TenantLoadingSkeleton } from "@/src/components/TenantLoadingSkeleton";
+import { TenantProvider } from "@/src/contexts/TenantProvider";
+import { useTenant } from "@/src/hooks/useTenant";
+
+function DashboardContent() {
+  const { config, isLoading, error, refreshConfig, language, setLanguage, tenantSlug } = useTenant();
+
+  if (isLoading || !config) return <TenantLoadingSkeleton />;
+  if (error) return <TenantError error={error} onRetry={() => refreshConfig()} />;
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <p className="text-sm text-gray-500 uppercase">Tenant</p>
+          <h1 className="text-3xl font-bold text-gray-900">{config.tenant.name}</h1>
+          <p className="text-gray-600">Slug: {tenantSlug}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-gray-700" htmlFor="language-select">
+            Language
+          </label>
+          <select
+            id="language-select"
+            className="border rounded px-2 py-1"
+            value={language}
+            onChange={(event) => setLanguage(event.target.value)}
+          >
+            <option value="cs">Czech</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+      </header>
+
+      <section aria-label="Factory map" className="space-y-3">
+        <FactoryMap />
+      </section>
+
+      <section aria-label="Audit game" className="space-y-3">
+        <AuditGame />
+      </section>
+
+      <section aria-label="LPA game" className="space-y-3">
+        <LPAGame />
+      </section>
+    </div>
+  );
+}
+
+export default function TenantDashboardPage() {
+  return (
+    <TenantProvider>
+      <DashboardContent />
+    </TenantProvider>
+  );
+}

--- a/frontend/src/components/AuditGame.tsx
+++ b/frontend/src/components/AuditGame.tsx
@@ -1,110 +1,226 @@
 "use client";
 
-import React, { useEffect } from "react";
-import type { AuditScene } from "@/types/audit";
-import { useAuditStore } from "@/src/store/auditStore";
-import { AuditCanvas } from "./AuditCanvas";
-import { AuditCategorization } from "./AuditCategorization";
-import { AuditResults } from "./AuditResults";
-import { AuditSceneSelector } from "./AuditSceneSelector";
+import { useMemo, useState } from "react";
+import { API_BASE_URL } from "@/src/constants";
+import { TenantError } from "@/src/components/TenantError";
+import { TenantLoadingSkeleton } from "@/src/components/TenantLoadingSkeleton";
+import { useTenant } from "@/src/hooks/useTenant";
 
-interface AuditGameProps {
-  scene: AuditScene | null;
-  onSelectScene: (scene: AuditScene) => void;
-  onComplete: () => void;
-}
+const difficultyOptions = ["all", "easy", "medium", "hard"] as const;
 
-export const AuditGame: React.FC<AuditGameProps> = ({
-  scene,
-  onSelectScene,
-  onComplete,
-}) => {
-  const status = useAuditStore((state) => state.status);
-  const foundProblems = useAuditStore((state) => state.foundProblems);
-  const timeRemaining = useAuditStore((state) => state.timeRemaining);
-  const startAudit = useAuditStore((state) => state.startAudit);
-  const finishAudit = useAuditStore((state) => state.finishAudit);
-  const decrementTime = useAuditStore((state) => state.decrementTime);
-  const resetAudit = useAuditStore((state) => state.resetAudit);
+export function AuditGame() {
+  const { config, isLoading, error, refreshConfig } = useTenant();
+  const audits = useMemo(() => config?.auditTemplates ?? [], [config?.auditTemplates]);
+  const [selectedAuditId, setSelectedAuditId] = useState<string | null>(null);
+  const [difficultyFilter, setDifficultyFilter] = useState<(typeof difficultyOptions)[number]>("all");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [itemStatus, setItemStatus] = useState<Record<string, boolean>>({});
+  const [feedback, setFeedback] = useState<string>("");
 
-  useEffect(() => {
-    if (!scene) return;
-    startAudit(scene);
-  }, [scene, startAudit]);
+  const filteredAudits = useMemo(() => {
+    return audits.filter((audit) => {
+      const matchesDifficulty =
+        difficultyFilter === "all" || audit.difficulty.toLowerCase() === difficultyFilter;
+      const matchesCategory = categoryFilter === "all" || audit.category === categoryFilter;
+      return matchesDifficulty && matchesCategory;
+    });
+  }, [audits, categoryFilter, difficultyFilter]);
 
-  useEffect(() => {
-    if (status !== "playing") return;
+  const selectedAudit = audits.find((audit) => audit.id === selectedAuditId) ?? null;
 
-    const interval = setInterval(() => {
-      const remaining = decrementTime();
-      if (remaining <= 0) {
-        finishAudit();
-      }
-    }, 1000);
+  const handleStartAudit = (auditId: string) => {
+    setSelectedAuditId(auditId);
+    setFeedback("");
+    const audit = audits.find((entry) => entry.id === auditId);
+    if (audit) {
+      const initialStatus = audit.items.reduce<Record<string, boolean>>((acc, item) => {
+        acc[item.id] = Boolean(item.status === "done");
+        return acc;
+      }, {});
+      setItemStatus(initialStatus);
+    }
+  };
 
-    return () => clearInterval(interval);
-  }, [status, decrementTime, finishAudit]);
+  const handleToggleItem = (itemId: string) => {
+    setItemStatus((prev) => ({ ...prev, [itemId]: !prev[itemId] }));
+  };
 
-  useEffect(() => {
-    return () => resetAudit();
-  }, [resetAudit]);
+  const completedCount = useMemo(() => {
+    return Object.values(itemStatus).filter(Boolean).length;
+  }, [itemStatus]);
 
-  if (!scene) {
-    return <AuditSceneSelector onSelectScene={onSelectScene} />;
-  }
+  const handleCompleteAudit = async () => {
+    if (!selectedAudit) return;
+    const payload = {
+      auditId: selectedAudit.id,
+      completedItems: Object.entries(itemStatus)
+        .filter(([, done]) => done)
+        .map(([id]) => id),
+    };
 
-  if (status === "finished") {
+    try {
+      await fetch(`${API_BASE_URL}/api/audits/${selectedAudit.id}/results`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      setFeedback(`Audit complete! Earned ${selectedAudit.xpReward} XP.`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to save audit results";
+      setFeedback(message);
+    }
+  };
+
+  if (isLoading) return <TenantLoadingSkeleton />;
+  if (error) return <TenantError error={error} onRetry={() => refreshConfig()} />;
+
+  if (!audits.length) {
     return (
-      <AuditResults
-        onNext={() => {
-          resetAudit();
-          onComplete();
-        }}
-      />
+      <div className="p-6 bg-white rounded-lg shadow-sm">
+        <h2 className="text-xl font-semibold">Available Audits</h2>
+        <p className="text-sm text-gray-600 mt-2">No audits configured for this tenant.</p>
+      </div>
     );
   }
 
-  return (
-    <div className="space-y-6" role="region" aria-label="5S audit mini-game">
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">{scene.name}</h2>
-        <div className="text-lg font-semibold">
-          Time: {Math.floor(timeRemaining / 60)}:{String(timeRemaining % 60).padStart(2, "0")} /
-          {" "}
-          {Math.floor(scene.timeLimit / 60)}:{String(scene.timeLimit % 60).padStart(2, "0")}
+  if (selectedAudit) {
+    const totalItems = selectedAudit.items.length || 1;
+    const progress = Math.round((completedCount / totalItems) * 100);
+
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold">{selectedAudit.title}</h2>
+            <p className="text-sm text-gray-600">{selectedAudit.description}</p>
+          </div>
+          <button
+            type="button"
+            className="text-sm text-blue-600 hover:underline"
+            onClick={() => setSelectedAuditId(null)}
+          >
+            ← Back to list
+          </button>
         </div>
-      </div>
 
-      <AuditCanvas scene={scene} foundProblems={foundProblems} />
-
-      <div>
-        <h3 className="font-semibold mb-2">
-          Found Problems: {foundProblems.length}/{scene.problems.length}
-        </h3>
-        <div className="bg-blue-50 p-4 rounded">
-          {foundProblems.length === 0 ? (
-            <p className="text-gray-600">Click on issues in the image to mark them</p>
-          ) : (
-            <div className="space-y-2">
-              {foundProblems.map((id) => (
-                <div key={id} className="text-sm text-blue-700">
-                  ✓ Problem {id} - select the 5S category below
-                </div>
-              ))}
+        <div className="bg-white rounded-lg shadow-sm p-4">
+          <div className="flex justify-between items-center mb-4">
+            <div>
+              <p className="text-sm text-gray-600">Difficulty: {selectedAudit.difficulty}</p>
+              <p className="text-sm text-gray-600">Category: {selectedAudit.category}</p>
             </div>
-          )}
+            <div className="text-sm font-semibold">XP Reward: {selectedAudit.xpReward}</div>
+          </div>
+
+          <div className="w-full bg-gray-100 h-3 rounded-full mb-4">
+            <div
+              className="h-3 rounded-full bg-green-500"
+              style={{ width: `${progress}%` }}
+              aria-valuenow={progress}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
+
+          <ul className="space-y-2">
+            {selectedAudit.items.map((item) => (
+              <li key={item.id} className="flex items-start gap-3 border rounded p-3">
+                <input
+                  type="checkbox"
+                  checked={Boolean(itemStatus[item.id])}
+                  onChange={() => handleToggleItem(item.id)}
+                  className="mt-1"
+                  aria-label={`Mark ${item.name} as complete`}
+                />
+                <div>
+                  <p className="font-medium">{item.name}</p>
+                  {item.status && (
+                    <p className="text-xs text-gray-600">Status: {item.status}</p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex items-center justify-between mt-4">
+            <span className="text-sm text-gray-700">
+              Progress: {completedCount}/{selectedAudit.items.length}
+            </span>
+            <button
+              type="button"
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              onClick={handleCompleteAudit}
+            >
+              Complete Audit
+            </button>
+          </div>
+          {feedback && <p className="text-sm text-gray-700 mt-3">{feedback}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  const categories = Array.from(new Set(audits.map((audit) => audit.category)));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col md:flex-row md:items-end gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">Available Audits</h2>
+          <p className="text-sm text-gray-600">Choose a template to start a checklist.</p>
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          <label className="text-sm text-gray-700">
+            Difficulty
+            <select
+              className="ml-2 border rounded px-2 py-1"
+              value={difficultyFilter}
+              onChange={(event) =>
+                setDifficultyFilter(event.target.value as (typeof difficultyOptions)[number])
+              }
+            >
+              {difficultyOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm text-gray-700">
+            Category
+            <select
+              className="ml-2 border rounded px-2 py-1"
+              value={categoryFilter}
+              onChange={(event) => setCategoryFilter(event.target.value)}
+            >
+              <option value="all">all</option>
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+          </label>
         </div>
       </div>
 
-      {foundProblems.length > 0 && <AuditCategorization scene={scene} />}
-
-      <button
-        onClick={() => finishAudit()}
-        className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700"
-        disabled={status !== "playing"}
-      >
-        Finish Audit
-      </button>
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredAudits.map((audit) => (
+          <button
+            key={audit.id}
+            type="button"
+            onClick={() => handleStartAudit(audit.id)}
+            className="text-left bg-white border rounded-lg p-4 shadow-sm hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          >
+            <h3 className="text-lg font-semibold mb-1">{audit.title}</h3>
+            <p className="text-sm text-gray-600 mb-2 line-clamp-2">{audit.description}</p>
+            <div className="text-xs text-gray-500 flex gap-4">
+              <span>Difficulty: {audit.difficulty}</span>
+              <span>Category: {audit.category}</span>
+            </div>
+          </button>
+        ))}
+      </div>
     </div>
   );
-};
+}

--- a/frontend/src/components/FactoryMap.tsx
+++ b/frontend/src/components/FactoryMap.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTenant } from "@/src/hooks/useTenant";
+import { TenantLoadingSkeleton } from "@/src/components/TenantLoadingSkeleton";
+import { TenantError } from "@/src/components/TenantError";
+
+const statusColors: Record<string, string> = {
+  optimal: "fill-green-500",
+  warning: "fill-yellow-400",
+  critical: "fill-red-500",
+};
+
+export function FactoryMap() {
+  const { config, isLoading, error, refreshConfig } = useTenant();
+  const factories = useMemo(() => config?.factories ?? [], [config?.factories]);
+  const [selectedFactoryId, setSelectedFactoryId] = useState<string | undefined>(
+    factories?.[0]?.id
+  );
+  const [selectedZoneId, setSelectedZoneId] = useState<string | null>(null);
+
+  const selectedFactory = useMemo(
+    () => factories.find((factory) => factory.id === selectedFactoryId) ?? factories[0],
+    [factories, selectedFactoryId]
+  );
+
+  const selectedZone = useMemo(
+    () => selectedFactory?.zones.find((zone) => zone.id === selectedZoneId) ?? null,
+    [selectedFactory, selectedZoneId]
+  );
+
+  if (isLoading) return <TenantLoadingSkeleton />;
+  if (error) return <TenantError error={error} onRetry={() => refreshConfig()} />;
+
+  if (!factories.length) {
+    return (
+      <div className="p-6 bg-white rounded-lg shadow-sm">
+        <h2 className="text-xl font-semibold mb-2">Factories</h2>
+        <p className="text-sm text-gray-600">No factory data available for this tenant.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold">Factory Map</h2>
+          <p className="text-sm text-gray-600">
+            Visualize zones and workshops from the tenant configuration.
+          </p>
+        </div>
+        <select
+          className="border rounded px-3 py-2 w-full md:w-64"
+          value={selectedFactory?.id}
+          onChange={(event) => {
+            setSelectedFactoryId(event.target.value);
+            setSelectedZoneId(null);
+          }}
+        >
+          {factories.map((factory) => (
+            <option key={factory.id} value={factory.id}>
+              {factory.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <div className="relative overflow-auto">
+          <svg viewBox="0 0 800 600" className="w-full h-auto min-h-[300px]">
+            {selectedFactory?.zones.map((zone) => (
+              <g
+                key={zone.id}
+                transform={`translate(${zone.coordinates.x}, ${zone.coordinates.y})`}
+                className="cursor-pointer"
+                onClick={() => setSelectedZoneId(zone.id)}
+              >
+                <circle
+                  r="30"
+                  className={`${statusColors[zone.status] ?? "fill-gray-300"} drop-shadow`}
+                  aria-label={`Zone ${zone.name}`}
+                />
+                <text
+                  x="0"
+                  y="50"
+                  textAnchor="middle"
+                  className="text-sm fill-gray-800"
+                >
+                  {zone.name}
+                </text>
+              </g>
+            ))}
+          </svg>
+        </div>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className="p-4 bg-white rounded-lg shadow-sm">
+          <h3 className="text-lg font-semibold mb-2">Workshops</h3>
+          {selectedFactory?.workshops.length ? (
+            <ul className="space-y-2">
+              {selectedFactory.workshops.map((workshop) => (
+                <li
+                  key={workshop.id}
+                  className="flex items-center justify-between border rounded p-3"
+                >
+                  <div>
+                    <p className="font-medium">{workshop.name}</p>
+                    <p className="text-sm text-gray-600">Red tags: {workshop.redTags}</p>
+                  </div>
+                  <span className="text-sm text-gray-700">
+                    Training: {workshop.activeTraining}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-600">No workshops defined.</p>
+          )}
+        </div>
+
+        <div className="p-4 bg-white rounded-lg shadow-sm">
+          <h3 className="text-lg font-semibold mb-2">Zone Detail</h3>
+          {selectedZone ? (
+            <div className="space-y-1 text-sm text-gray-700">
+              <p className="font-semibold">{selectedZone.name}</p>
+              <p>Status: {selectedZone.status}</p>
+              <p>
+                Coordinates: x={selectedZone.coordinates.x}, y={selectedZone.coordinates.y}
+              </p>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-600">Select a zone to view details.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/LPAGame.tsx
+++ b/frontend/src/components/LPAGame.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { API_BASE_URL } from "@/src/constants";
+import { TenantError } from "@/src/components/TenantError";
+import { TenantLoadingSkeleton } from "@/src/components/TenantLoadingSkeleton";
+import { useTenant } from "@/src/hooks/useTenant";
+
+const ANSWERS = ["Compliant", "Needs Improvement", "Not Applicable", "Escalate"];
+
+export function LPAGame() {
+  const { config, isLoading, error, refreshConfig } = useTenant();
+  const lpaAudits = useMemo(() => config?.lpaTemplates ?? [], [config?.lpaTemplates]);
+
+  const [selectedAuditId, setSelectedAuditId] = useState<string | null>(null);
+  const [currentQuestion, setCurrentQuestion] = useState(0);
+  const [score, setScore] = useState(0);
+  const [resultMessage, setResultMessage] = useState<string>("");
+  const [answers, setAnswers] = useState<string[]>([]);
+
+  const selectedAudit = useMemo(
+    () => lpaAudits.find((audit) => audit.id === selectedAuditId) ?? null,
+    [lpaAudits, selectedAuditId]
+  );
+
+  const resetAudit = () => {
+    setSelectedAuditId(null);
+    setCurrentQuestion(0);
+    setScore(0);
+    setAnswers([]);
+    setResultMessage("");
+  };
+
+  const handleStartAudit = (auditId: string) => {
+    setSelectedAuditId(auditId);
+    setCurrentQuestion(0);
+    setScore(0);
+    setAnswers([]);
+    setResultMessage("");
+  };
+
+  const handleAnswer = async (answer: string) => {
+    if (!selectedAudit) return;
+    const question = selectedAudit.questions[currentQuestion];
+    const isCorrect = ANSWERS[0] === answer;
+
+    if (isCorrect) {
+      setScore((prev) => prev + 1);
+    }
+
+    setAnswers((prev) => [...prev, answer]);
+
+    try {
+      await fetch(`${API_BASE_URL}/api/lpa/${selectedAudit.id}/answers`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ questionId: question.id, answer }),
+      });
+    } catch (err) {
+      console.warn("Unable to validate LPA answer", err);
+    }
+
+    if (currentQuestion + 1 < selectedAudit.questions.length) {
+      setCurrentQuestion((prev) => prev + 1);
+    } else {
+      const totalQuestions = selectedAudit.questions.length;
+      const xpEarned = Math.round((score + (isCorrect ? 1 : 0)) / totalQuestions * selectedAudit.xpReward);
+      setResultMessage(`Quiz complete! Score: ${score + (isCorrect ? 1 : 0)}/${totalQuestions}. XP: ${xpEarned}`);
+    }
+  };
+
+  if (isLoading) return <TenantLoadingSkeleton />;
+  if (error) return <TenantError error={error} onRetry={() => refreshConfig()} />;
+
+  if (!lpaAudits.length) {
+    return (
+      <div className="p-6 bg-white rounded-lg shadow-sm">
+        <h2 className="text-xl font-semibold">Layered Process Audits</h2>
+        <p className="text-sm text-gray-600 mt-2">No LPA templates configured for this tenant.</p>
+      </div>
+    );
+  }
+
+  if (selectedAudit) {
+    const totalQuestions = selectedAudit.questions.length;
+    const question = selectedAudit.questions[currentQuestion];
+    const progress = Math.round(((currentQuestion + (resultMessage ? 1 : 0)) / totalQuestions) * 100);
+
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold">{selectedAudit.title}</h2>
+            <p className="text-sm text-gray-600">{selectedAudit.description}</p>
+          </div>
+          <button
+            type="button"
+            className="text-sm text-blue-600 hover:underline"
+            onClick={resetAudit}
+          >
+            ← Back to list
+          </button>
+        </div>
+
+        <div className="bg-white rounded-lg shadow-sm p-4">
+          <div className="flex justify-between items-center mb-4 text-sm text-gray-700">
+            <span>
+              Question {Math.min(currentQuestion + 1, totalQuestions)} / {totalQuestions}
+            </span>
+            <span>XP Reward: {selectedAudit.xpReward}</span>
+          </div>
+
+          {!resultMessage ? (
+            <div className="space-y-4">
+              <p className="text-lg font-semibold">{question.question}</p>
+              <div className="grid md:grid-cols-2 gap-3">
+                {ANSWERS.map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    className="border rounded-lg p-3 text-left hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                    onClick={() => handleAnswer(option)}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+              <div className="w-full bg-gray-100 h-3 rounded-full">
+                <div
+                  className="h-3 rounded-full bg-blue-500"
+                  style={{ width: `${progress}%` }}
+                  aria-valuenow={progress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                />
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-lg font-semibold">{resultMessage}</p>
+              <button
+                type="button"
+                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                onClick={resetAudit}
+              >
+                Start another audit
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-2xl font-semibold">Layered Process Audits</h2>
+        <p className="text-sm text-gray-600">Launch a quiz from the available templates.</p>
+      </div>
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {lpaAudits.map((audit) => (
+          <button
+            key={audit.id}
+            type="button"
+            onClick={() => handleStartAudit(audit.id)}
+            className="text-left bg-white border rounded-lg p-4 shadow-sm hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          >
+            <h3 className="text-lg font-semibold mb-1">{audit.title}</h3>
+            <p className="text-sm text-gray-600 mb-2 line-clamp-2">{audit.description}</p>
+            <div className="text-xs text-gray-500 flex gap-4">
+              <span>Frequency: {audit.frequency}</span>
+              <span>XP: {audit.xpReward}</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TenantError.tsx
+++ b/frontend/src/components/TenantError.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+interface TenantErrorProps {
+  error: Error;
+  onRetry: () => void;
+}
+
+export function TenantError({ error, onRetry }: TenantErrorProps) {
+  return (
+    <div className="p-6 bg-red-50 border border-red-200 rounded-lg text-red-900 space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">⚠️ Tenant Loading Failed</h2>
+        <p className="text-sm text-red-800 mt-1">{error.message}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/TenantLoadingSkeleton.tsx
+++ b/frontend/src/components/TenantLoadingSkeleton.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+export function TenantLoadingSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse" aria-busy="true">
+      <div className="h-10 bg-gray-200 rounded" />
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="h-40 bg-gray-200 rounded" />
+        <div className="h-40 bg-gray-200 rounded" />
+        <div className="h-40 bg-gray-200 rounded" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,0 +1,17 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+export const COLORS = {
+  success: "#16a34a",
+  warning: "#f59e0b",
+  danger: "#dc2626",
+};
+
+export const FEATURE_FLAGS = {
+  enableTenantDashboard: true,
+};
+
+export const VALIDATION_RULES = {
+  tenantSlug: /^[a-z0-9-]+$/,
+};
+
+export const TENANT_CACHE_TTL = 300_000; // 5 minutes

--- a/frontend/src/contexts/TenantContext.tsx
+++ b/frontend/src/contexts/TenantContext.tsx
@@ -1,0 +1,6 @@
+"use client";
+
+import { createContext } from "react";
+import type { TenantContextType } from "@/src/types/tenant";
+
+export const TenantContext = createContext<TenantContextType | undefined>(undefined);

--- a/frontend/src/contexts/TenantProvider.tsx
+++ b/frontend/src/contexts/TenantProvider.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { VALIDATION_RULES } from "@/src/constants";
+import { TenantContext } from "@/src/contexts/TenantContext";
+import { clearCachedConfig, getCachedConfig, setCachedConfig } from "@/src/lib/cache";
+import { fetchTenantConfig } from "@/src/lib/tenantApi";
+import type { TenantConfig } from "@/src/types/tenant";
+
+interface TenantProviderProps {
+  children: ReactNode;
+  initialSlug?: string;
+}
+
+const SLUG_REGEX = VALIDATION_RULES.tenantSlug;
+
+function extractSlug(pathname: string | null): string | null {
+  if (!pathname) return null;
+  const segments = pathname.split("/").filter(Boolean);
+  const tenantIndex = segments.findIndex((segment) => segment === "tenant");
+  if (tenantIndex === -1 || tenantIndex + 1 >= segments.length) return null;
+  const slug = segments[tenantIndex + 1];
+  return SLUG_REGEX.test(slug) ? slug : null;
+}
+
+function readLanguage(slug: string | null): string | null {
+  if (typeof window === "undefined") return null;
+  if (!slug) return null;
+  try {
+    return localStorage.getItem(`tenant:language:${slug}`);
+  } catch (error) {
+    console.warn("Unable to read tenant language", error);
+    return null;
+  }
+}
+
+function persistLanguage(slug: string | null, language: string): void {
+  if (typeof window === "undefined") return;
+  if (!slug) return;
+  try {
+    localStorage.setItem(`tenant:language:${slug}`, language);
+  } catch (error) {
+    console.warn("Unable to persist tenant language", error);
+  }
+}
+
+export function TenantProvider({ children, initialSlug }: TenantProviderProps) {
+  const pathname = usePathname();
+  const derivedSlug = extractSlug(pathname);
+  const tenantSlug = initialSlug ?? derivedSlug;
+  const isValidSlug = tenantSlug ? SLUG_REGEX.test(tenantSlug) : false;
+
+  const [config, setConfig] = useState<TenantConfig | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [language, setLanguageState] = useState<string>(() => "en");
+  const isFetchingRef = useRef(false);
+
+  const loadLanguage = useCallback(
+    (nextConfig?: TenantConfig | null) => {
+      const slug = tenantSlug ?? nextConfig?.tenant.slug ?? null;
+      const storedLanguage = readLanguage(slug);
+      if (storedLanguage) {
+        setLanguageState(storedLanguage);
+        return;
+      }
+      if (nextConfig?.tenant.language) {
+        setLanguageState(nextConfig.tenant.language);
+      }
+    },
+    [tenantSlug]
+  );
+
+  const loadConfig = useCallback(
+    async (bypassCache = false) => {
+      if (!tenantSlug || !isValidSlug) {
+        setError(new Error("Tenant slug is missing or invalid"));
+        setConfig(null);
+        return;
+      }
+
+      if (isFetchingRef.current) return;
+
+      isFetchingRef.current = true;
+      setIsLoading(true);
+      setError(null);
+
+      const cachedConfig = !bypassCache ? getCachedConfig(tenantSlug) : null;
+      if (cachedConfig) {
+        setConfig(cachedConfig);
+        loadLanguage(cachedConfig);
+        setIsLoading(false);
+        isFetchingRef.current = false;
+        return;
+      }
+
+      try {
+        const data = await fetchTenantConfig(tenantSlug);
+        setConfig(data);
+        setCachedConfig(tenantSlug, data);
+        loadLanguage(data);
+      } catch (err) {
+        const errorInstance =
+          err instanceof Error ? err : new Error("Unknown tenant load error");
+        setError(errorInstance);
+        setConfig(null);
+      } finally {
+        setIsLoading(false);
+        isFetchingRef.current = false;
+      }
+    },
+    [isValidSlug, loadLanguage, tenantSlug]
+  );
+
+  useEffect(() => {
+    if (!tenantSlug || !isValidSlug) {
+      setError(new Error("Tenant slug is missing or invalid"));
+      setConfig(null);
+      return;
+    }
+
+    const cachedLanguage = readLanguage(tenantSlug);
+    if (cachedLanguage) {
+      setLanguageState(cachedLanguage);
+    }
+
+    void loadConfig();
+  }, [tenantSlug, isValidSlug, loadConfig]);
+
+  const refreshConfig = useCallback(async () => {
+    if (!tenantSlug || !isValidSlug) return;
+    clearCachedConfig(tenantSlug);
+    await loadConfig(true);
+  }, [isValidSlug, loadConfig, tenantSlug]);
+
+  const setLanguage = useCallback(
+    (lang: string) => {
+      setLanguageState(lang);
+      persistLanguage(tenantSlug ?? config?.tenant.slug ?? null, lang);
+    },
+    [config?.tenant.slug, tenantSlug]
+  );
+
+  const value = useMemo(
+    () => ({
+      config,
+      isLoading,
+      error,
+      tenantSlug: tenantSlug ?? config?.tenant.slug ?? null,
+      language,
+      setLanguage,
+      refreshConfig,
+    }),
+    [config, error, isLoading, language, refreshConfig, setLanguage, tenantSlug]
+  );
+
+  return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>;
+}

--- a/frontend/src/hooks/useTenant.ts
+++ b/frontend/src/hooks/useTenant.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useContext } from "react";
+import { TenantContext } from "@/src/contexts/TenantContext";
+
+export function useTenant() {
+  const context = useContext(TenantContext);
+  if (!context) {
+    throw new Error("useTenant must be used within a TenantProvider");
+  }
+  return context;
+}

--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -1,0 +1,46 @@
+import { TENANT_CACHE_TTL } from "@/src/constants";
+import type { TenantConfig } from "@/src/types/tenant";
+
+interface CacheEntry {
+  data: TenantConfig;
+  timestamp: number;
+  ttl: number;
+}
+
+function isCacheValid(entry: CacheEntry): boolean {
+  const age = Date.now() - entry.timestamp;
+  return age < entry.ttl;
+}
+
+export function getCachedConfig(slug: string): TenantConfig | null {
+  try {
+    const stored = localStorage.getItem(`tenant:config:${slug}`);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored) as CacheEntry;
+    return isCacheValid(parsed) ? parsed.data : null;
+  } catch (error) {
+    console.warn("Failed to read cached tenant config", error);
+    return null;
+  }
+}
+
+export function setCachedConfig(slug: string, config: TenantConfig): void {
+  try {
+    const entry: CacheEntry = {
+      data: config,
+      timestamp: Date.now(),
+      ttl: TENANT_CACHE_TTL,
+    };
+    localStorage.setItem(`tenant:config:${slug}`, JSON.stringify(entry));
+  } catch (error) {
+    console.warn("Failed to write tenant cache", error);
+  }
+}
+
+export function clearCachedConfig(slug: string): void {
+  try {
+    localStorage.removeItem(`tenant:config:${slug}`);
+  } catch (error) {
+    console.warn("Failed to clear tenant cache", error);
+  }
+}

--- a/frontend/src/lib/tenantApi.ts
+++ b/frontend/src/lib/tenantApi.ts
@@ -1,0 +1,30 @@
+import { API_BASE_URL } from "@/src/constants";
+import type { TenantConfig } from "@/src/types/tenant";
+
+export async function fetchTenantConfig(slug: string): Promise<TenantConfig> {
+  if (!API_BASE_URL) {
+    throw new Error("API_BASE_URL is not configured");
+  }
+
+  const response = await fetch(`${API_BASE_URL}/api/tenants/${slug}/config`, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+  });
+
+  if (response.status === 404) {
+    throw new Error("Tenant not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load tenant config (${response.status})`);
+  }
+
+  try {
+    const data = (await response.json()) as TenantConfig;
+    return data;
+  } catch (error) {
+    throw new Error("Failed to parse tenant config response");
+  }
+}

--- a/frontend/src/types/tenant.ts
+++ b/frontend/src/types/tenant.ts
@@ -1,0 +1,56 @@
+export interface TenantConfig {
+  tenant: {
+    id: string;
+    slug: string;
+    name: string;
+    language: string;
+    timezone: string;
+    primaryColor: string;
+    secondaryColor: string;
+    leanMethodologies: string[];
+  };
+  factories: Array<{
+    id: string;
+    name: string;
+    type: string;
+    zones: Array<{
+      id: string;
+      name: string;
+      coordinates: { x: number; y: number };
+      status: string;
+    }>;
+    workshops: Array<{
+      id: string;
+      name: string;
+      redTags: number;
+      activeTraining: number;
+    }>;
+  }>;
+  auditTemplates: Array<{
+    id: string;
+    title: string;
+    description: string;
+    difficulty: string;
+    category: string;
+    items: Array<{ id: string; name: string; status?: string }>;
+    xpReward: number;
+  }>;
+  lpaTemplates: Array<{
+    id: string;
+    title: string;
+    description: string;
+    frequency: string;
+    questions: Array<{ id: string; question: string; category: string }>;
+    xpReward: number;
+  }>;
+}
+
+export interface TenantContextType {
+  config: TenantConfig | null;
+  isLoading: boolean;
+  error: Error | null;
+  tenantSlug: string | null;
+  language: string;
+  setLanguage: (lang: string) => void;
+  refreshConfig: () => Promise<void>;
+}


### PR DESCRIPTION
## Summary
- implement tenant context, caching utilities, and API wrapper for loading tenant configuration
- add dynamic FactoryMap, AuditGame, and LPAGame components driven by tenant config with loading/error states
- create tenant dashboard route and update existing game pages to use the new tenant provider

## Testing
- npm run lint *(fails: ESLint rule '@typescript-eslint/no-unused-vars' missing in current setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bd0084af0833090af53ea0185409e)